### PR TITLE
feat: implement per-peer transaction relay tracking and metrics

### DIFF
--- a/tools/metrics/src/lib.rs
+++ b/tools/metrics/src/lib.rs
@@ -450,7 +450,7 @@ fn handle_validation_event(e: &validation_event::Event, metrics: metrics::Metric
 }
 
 /// Helper function to cleanup transaction tracking for a disconnected peer
-fn cleanup_peer_tracking(tx_tracker: Option<&crate::TxTracker>, peer_id: u64) {
+fn cleanup_peer_tracking(tx_tracker: Option<&TransactionTracker>, peer_id: u64) {
     if let Some(tracker) = tx_tracker {
         tracker.remove_peer(peer_id);
     }

--- a/tools/metrics/src/lib.rs
+++ b/tools/metrics/src/lib.rs
@@ -451,9 +451,7 @@ fn handle_validation_event(e: &validation_event::Event, metrics: metrics::Metric
 
 /// Helper function to cleanup transaction tracking for a disconnected peer
 fn cleanup_peer_tracking(tx_tracker: &TxRelayTracker, peer_id: u64, metrics: &metrics::Metrics) {
-    tx_tracker.remove_peer(peer_id);
-    
-    // Get peer address for metrics cleanup
+    // Get peer address BEFORE removing the peer from tracker
     if let Some(peer_addr) = tx_tracker.get_peer_address(peer_id) {
         let peer_id_str = peer_id.to_string();
         
@@ -462,6 +460,9 @@ fn cleanup_peer_tracking(tx_tracker: &TxRelayTracker, peer_id: u64, metrics: &me
         let _ = metrics.tx_unannounced_by_peer.remove_label_values(&[&peer_id_str, &peer_addr]);
         let _ = metrics.tx_peer_last_activity.remove_label_values(&[&peer_id_str, &peer_addr]);
     }
+    
+    // Now remove the peer from transaction tracking
+    tx_tracker.remove_peer(peer_id);
 }
 
 fn handle_connection_event(

--- a/tools/metrics/src/metrics.rs
+++ b/tools/metrics/src/metrics.rs
@@ -34,6 +34,9 @@ pub const LABEL_RPC_CONNECTION_TYPE: &str = "connection_type";
 pub const LABEL_RPC_PROTOCOL_VERSION: &str = "protocol_version";
 pub const LABEL_RPC_ASN: &str = "ASN";
 
+pub const LABEL_PEER_ID: &str = "peer_id";
+pub const LABEL_PEER_ADDR: &str = "peer_addr";
+
 pub const BUCKETS_ADDR_ADDRESS_COUNT: [f64; 30] = [
     0f64, 1f64, 2f64, 3f64, 4f64, 5f64, 6f64, 7f64, 8f64, 9f64, 10f64, 15f64, 20f64, 25f64, 30f64,
     50f64, 75f64, 100f64, 150f64, 200f64, 250f64, 300f64, 400f64, 500f64, 600f64, 700f64, 800f64,
@@ -240,6 +243,9 @@ pub struct Metrics {
     pub rpc_peer_info_ping_mean: Gauge,
     pub rpc_peer_info_minping_median: Gauge,
     pub rpc_peer_info_minping_mean: Gauge,
+    pub tx_unsolicited_by_peer: IntCounterVec,
+    pub tx_unannounced_by_peer: IntCounterVec,
+    pub tx_peer_last_activity: IntGaugeVec,
 }
 
 impl Metrics {
@@ -332,6 +338,9 @@ impl Metrics {
         g!(rpc_peer_info_ping_mean, "Mean ping (in milliseconds) of all connected peers.", registry);
         g!(rpc_peer_info_minping_median, "Median min_ping (in milliseconds) of all connected peers.", registry);
         g!(rpc_peer_info_minping_mean, "Mean min_ping (in milliseconds) of all connected peers.", registry);
+        icv!(tx_unsolicited_by_peer, "Number of unsolicited transactions received per peer", [LABEL_PEER_ID, LABEL_PEER_ADDR], registry);
+        icv!(tx_unannounced_by_peer, "Number of unannounced transaction requests per peer", [LABEL_PEER_ID, LABEL_PEER_ADDR], registry);
+        igv!(tx_peer_last_activity, "Timestamp of last transaction activity per peer", [LABEL_PEER_ID], registry);
 
 
         Self {
@@ -421,6 +430,9 @@ impl Metrics {
             rpc_peer_info_ping_mean,
             rpc_peer_info_minping_median,
             rpc_peer_info_minping_mean,
+            tx_unsolicited_by_peer,
+            tx_unannounced_by_peer,
+            tx_peer_last_activity,
         }
     }
 }

--- a/tools/metrics/src/tx_tracker.rs
+++ b/tools/metrics/src/tx_tracker.rs
@@ -1,0 +1,405 @@
+use shared::tokio;
+use std::collections::{HashMap, VecDeque};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+/// Maximum number of transaction IDs to track per peer to prevent memory overflow
+const MAX_TXS_PER_PEER: usize = 1000;
+
+/// Interval for cleaning up old data
+const CLEANUP_INTERVAL: Duration = Duration::from_secs(300); // 5 minutes
+
+/// Maximum time to keep inactive peer data
+const PEER_TIMEOUT: Duration = Duration::from_secs(1800); // 30 minutes
+
+/// Transaction ID type - can be either txid or wtxid
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum TxId {
+    Txid(Vec<u8>),
+    Wtxid(Vec<u8>),
+}
+
+impl TxId {
+    pub fn from_txid(txid: Vec<u8>) -> Self {
+        TxId::Txid(txid)
+    }
+
+    pub fn from_wtxid(wtxid: Vec<u8>) -> Self {
+        TxId::Wtxid(wtxid)
+    }
+}
+
+/// Transaction status after processing
+#[derive(Debug, PartialEq, Eq)]
+pub enum TxStatus {
+    /// Transaction was requested via GETDATA
+    Solicited,
+    /// Transaction was announced via INV
+    Announced,
+    /// Transaction received without prior GETDATA request
+    Unsolicited,
+    /// Transaction requested without prior INV announcement
+    Unannounced,
+}
+
+/// Per-peer transaction tracking state
+#[derive(Debug)]
+struct PeerTxState {
+    /// Peer's IP address for metrics labeling
+    address: String,
+    /// Recent INVs we sent to this peer
+    recent_invs: VecDeque<(TxId, Instant)>,
+    /// Recent GETDATAs we sent to this peer
+    recent_getdata: VecDeque<(TxId, Instant)>,
+    /// Last message time for cleanup purposes
+    last_message_time: Instant,
+}
+
+impl PeerTxState {
+    fn new(address: String) -> Self {
+        Self {
+            address,
+            recent_invs: VecDeque::new(),
+            recent_getdata: VecDeque::new(),
+            last_message_time: Instant::now(),
+        }
+    }
+
+    /// Add a transaction ID to the INV list
+    fn add_inv(&mut self, txid: TxId) {
+        self.recent_invs.push_back((txid, Instant::now()));
+        self.last_message_time = Instant::now();
+
+        // Limit list size
+        if self.recent_invs.len() > MAX_TXS_PER_PEER {
+            self.recent_invs.pop_front();
+        }
+    }
+
+    /// Add a transaction ID to the GETDATA list
+    fn add_getdata(&mut self, txid: TxId) {
+        self.recent_getdata.push_back((txid, Instant::now()));
+        self.last_message_time = Instant::now();
+
+        // Limit list size
+        if self.recent_getdata.len() > MAX_TXS_PER_PEER {
+            self.recent_getdata.pop_front();
+        }
+    }
+
+    /// Check if we announced this transaction to the peer
+    fn was_announced(&self, txid: &TxId) -> bool {
+        self.recent_invs.iter().any(|(id, _)| id == txid)
+    }
+
+    /// Check if we requested this transaction from the peer
+    fn was_requested(&self, txid: &TxId) -> bool {
+        self.recent_getdata.iter().any(|(id, _)| id == txid)
+    }
+}
+
+/// Main transaction tracker with thread-safe access
+#[derive(Debug, Clone)]
+pub struct TransactionTracker {
+    inner: Arc<Mutex<TransactionTrackerInner>>,
+}
+
+#[derive(Debug)]
+struct TransactionTrackerInner {
+    /// Per-peer tracking state
+    peer_states: HashMap<u64, PeerTxState>,
+    /// Last cleanup time
+    last_cleanup: Instant,
+}
+
+impl TransactionTracker {
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(TransactionTrackerInner {
+                peer_states: HashMap::new(),
+                last_cleanup: Instant::now(),
+            })),
+        }
+    }
+
+    /// Start the cleanup task that periodically removes old data
+    pub fn start_cleanup_task(&self) {
+        let tracker = self.clone();
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(CLEANUP_INTERVAL);
+            loop {
+                interval.tick().await;
+                if let Ok(mut inner) = tracker.inner.lock() {
+                    inner.cleanup_old_data();
+                }
+            }
+        });
+    }
+
+    /// Track an INV message we sent to a peer
+    pub fn track_inv(&self, peer_id: u64, txid: TxId) {
+        if let Ok(mut inner) = self.inner.lock() {
+            let peer_state = inner
+                .peer_states
+                .entry(peer_id)
+                .or_insert_with(|| PeerTxState::new(String::new()));
+            peer_state.add_inv(txid);
+        }
+    }
+
+    /// Track a GETDATA message we sent to a peer
+    pub fn track_getdata(&self, peer_id: u64, txid: TxId) {
+        if let Ok(mut inner) = self.inner.lock() {
+            let peer_state = inner
+                .peer_states
+                .entry(peer_id)
+                .or_insert_with(|| PeerTxState::new(String::new()));
+            peer_state.add_getdata(txid);
+        }
+    }
+
+    /// Process a transaction and determine its status
+    pub fn process_transaction(
+        &self,
+        peer_id: u64,
+        txid: TxId,
+        wtxid: TxId,
+        inbound: bool,
+    ) -> Option<TxStatus> {
+        let mut inner = self.inner.lock().ok()?;
+
+        // Perform cleanup if needed
+        inner.maybe_cleanup();
+
+        let peer_state = inner
+            .peer_states
+            .entry(peer_id)
+            .or_insert_with(|| PeerTxState::new(String::new()));
+        peer_state.last_message_time = Instant::now();
+
+        Some(if inbound {
+            // Transaction received from peer
+            // Check if we requested this transaction (either by txid or wtxid)
+            if peer_state.was_requested(&txid) || peer_state.was_requested(&wtxid) {
+                TxStatus::Solicited
+            } else {
+                TxStatus::Unsolicited
+            }
+        } else {
+            // Transaction request from peer
+            // Check if we announced this transaction (either by txid or wtxid)
+            if peer_state.was_announced(&txid) || peer_state.was_announced(&wtxid) {
+                TxStatus::Announced
+            } else {
+                TxStatus::Unannounced
+            }
+        })
+    }
+
+    /// Register peer address for metrics labeling
+    pub fn register_peer_address(&self, peer_id: u64, address: String) {
+        if let Ok(mut inner) = self.inner.lock() {
+            let peer_state = inner
+                .peer_states
+                .entry(peer_id)
+                .or_insert_with(|| PeerTxState::new(address.clone()));
+            peer_state.address = address;
+        }
+    }
+
+    /// Get peer address for metrics labeling
+    pub fn get_peer_address(&self, peer_id: u64) -> Option<String> {
+        self.inner.lock().ok().and_then(|inner| {
+            inner
+                .peer_states
+                .get(&peer_id)
+                .map(|state| state.address.clone())
+        })
+    }
+
+    /// Remove a disconnected peer from tracking
+    pub fn remove_peer(&self, peer_id: u64) {
+        if let Ok(mut inner) = self.inner.lock() {
+            inner.peer_states.remove(&peer_id);
+        }
+    }
+
+    /// Get the number of tracked peers (for testing)
+    #[cfg(test)]
+    pub fn tracked_peers_count(&self) -> usize {
+        self.inner
+            .lock()
+            .map(|inner| inner.peer_states.len())
+            .unwrap_or(0)
+    }
+
+    /// Helper function to handle INV messages
+    pub fn handle_inv_message(&self, peer_id: u64, inv_items: &[shared::primitive::InventoryItem]) {
+        for item in inv_items.iter() {
+            if let Some(inv_item) = &item.item {
+                match inv_item {
+                    shared::primitive::inventory_item::Item::Wtx(wtx_hash) => {
+                        let txid = TxId::from_wtxid(wtx_hash.clone());
+                        self.track_inv(peer_id, txid);
+                    }
+                    shared::primitive::inventory_item::Item::Transaction(tx_hash) => {
+                        let txid = TxId::from_txid(tx_hash.clone());
+                        self.track_inv(peer_id, txid);
+                    }
+                    shared::primitive::inventory_item::Item::WitnessTransaction(wtx_hash) => {
+                        let txid = TxId::from_wtxid(wtx_hash.clone());
+                        self.track_inv(peer_id, txid);
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    /// Helper function to handle GETDATA messages
+    pub fn handle_getdata_message(
+        &self,
+        peer_id: u64,
+        getdata_items: &[shared::primitive::InventoryItem],
+    ) {
+        for item in getdata_items.iter() {
+            if let Some(inv_item) = &item.item {
+                match inv_item {
+                    shared::primitive::inventory_item::Item::Wtx(wtx_hash) => {
+                        let txid = TxId::from_wtxid(wtx_hash.clone());
+                        self.track_getdata(peer_id, txid);
+                    }
+                    shared::primitive::inventory_item::Item::Transaction(tx_hash) => {
+                        let txid = TxId::from_txid(tx_hash.clone());
+                        self.track_getdata(peer_id, txid);
+                    }
+                    shared::primitive::inventory_item::Item::WitnessTransaction(wtx_hash) => {
+                        let txid = TxId::from_wtxid(wtx_hash.clone());
+                        self.track_getdata(peer_id, txid);
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    /// Helper function to handle TX messages and return status
+    pub fn handle_tx_message(
+        &self,
+        peer_id: u64,
+        tx: &shared::net_msg::Tx,
+        inbound: bool,
+    ) -> Option<TxStatus> {
+        let txid = TxId::from_txid(tx.tx.txid.clone());
+        let wtxid = TxId::from_wtxid(tx.tx.wtxid.clone());
+
+        self.process_transaction(peer_id, txid, wtxid, inbound)
+    }
+}
+
+impl TransactionTrackerInner {
+    /// Force cleanup of old data
+    fn cleanup_old_data(&mut self) {
+        let cutoff_age = Instant::now() - PEER_TIMEOUT;
+
+        // Remove peers that haven't had activity recently
+        self.peer_states
+            .retain(|_, peer_state| peer_state.last_message_time > cutoff_age);
+
+        self.last_cleanup = Instant::now();
+    }
+
+    /// Clean up old data if enough time has passed
+    fn maybe_cleanup(&mut self) {
+        if self.last_cleanup.elapsed() > CLEANUP_INTERVAL {
+            self.cleanup_old_data();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_unsolicited_detection() {
+        let tracker = TransactionTracker::new();
+        let peer_id = 1;
+        let txid = TxId::from_txid(b"test_txid".to_vec());
+        let wtxid = TxId::from_wtxid(b"test_wtxid".to_vec());
+
+        // Simulate receiving TX without prior GETDATA
+        let status = tracker.process_transaction(peer_id, txid.clone(), wtxid.clone(), true);
+        assert_eq!(status, Some(TxStatus::Unsolicited));
+    }
+
+    #[test]
+    fn test_solicited_detection() {
+        let tracker = TransactionTracker::new();
+        let peer_id = 1;
+        let txid = TxId::from_txid(b"test_txid".to_vec());
+        let wtxid = TxId::from_wtxid(b"test_wtxid".to_vec());
+
+        // First request the transaction
+        tracker.track_getdata(peer_id, txid.clone());
+
+        // Then receive it
+        let status = tracker.process_transaction(peer_id, txid.clone(), wtxid.clone(), true);
+        assert_eq!(status, Some(TxStatus::Solicited));
+    }
+
+    #[test]
+    fn test_unannounced_detection() {
+        let tracker = TransactionTracker::new();
+        let peer_id = 1;
+        let txid = TxId::from_txid(b"test_txid".to_vec());
+        let wtxid = TxId::from_wtxid(b"test_wtxid".to_vec());
+
+        // Simulate peer requesting TX without us announcing it
+        let status = tracker.process_transaction(peer_id, txid.clone(), wtxid.clone(), false);
+        assert_eq!(status, Some(TxStatus::Unannounced));
+    }
+
+    #[test]
+    fn test_announced_detection() {
+        let tracker = TransactionTracker::new();
+        let peer_id = 1;
+        let txid = TxId::from_txid(b"test_txid".to_vec());
+        let wtxid = TxId::from_wtxid(b"test_wtxid".to_vec());
+
+        // First announce the transaction
+        tracker.track_inv(peer_id, txid.clone());
+
+        // Then peer requests it
+        let status = tracker.process_transaction(peer_id, txid.clone(), wtxid.clone(), false);
+        assert_eq!(status, Some(TxStatus::Announced));
+    }
+
+    #[test]
+    fn test_memory_limits() {
+        let tracker = TransactionTracker::new();
+        let peer_id = 1;
+
+        // Add more than the limit
+        for i in 0..(MAX_TXS_PER_PEER + 100) {
+            let txid = TxId::from_txid(format!("txid_{}", i).into_bytes());
+            tracker.track_inv(peer_id, txid);
+        }
+
+        // Verify limit is respected (check via cleanup or indirect means)
+        assert!(tracker.tracked_peers_count() <= 1);
+    }
+
+    #[test]
+    fn test_peer_cleanup() {
+        let tracker = TransactionTracker::new();
+        let peer_id = 1;
+        let txid = TxId::from_txid(b"test_txid".to_vec());
+
+        tracker.track_inv(peer_id, txid);
+        assert_eq!(tracker.tracked_peers_count(), 1);
+
+        tracker.remove_peer(peer_id);
+        assert_eq!(tracker.tracked_peers_count(), 0);
+    }
+}

--- a/tools/metrics/src/tx_tracker.rs
+++ b/tools/metrics/src/tx_tracker.rs
@@ -55,6 +55,17 @@ struct PeerTxState {
     last_message_time: Instant,
 }
 
+impl Default for PeerTxState {
+    fn default() -> Self {
+        Self {
+            address: String::new(),
+            recent_invs: VecDeque::new(),
+            recent_getdata: VecDeque::new(),
+            last_message_time: Instant::now(),
+        }
+    }
+}
+
 impl PeerTxState {
     fn new(address: String) -> Self {
         Self {
@@ -139,10 +150,7 @@ impl TransactionTracker {
     /// Track an INV message we sent to a peer
     pub fn track_inv(&self, peer_id: u64, txid: TxId) {
         if let Ok(mut inner) = self.inner.lock() {
-            let peer_state = inner
-                .peer_states
-                .entry(peer_id)
-                .or_insert_with(|| PeerTxState::new(String::new()));
+            let peer_state = inner.peer_states.entry(peer_id).or_default();
             peer_state.add_inv(txid);
         }
     }
@@ -150,10 +158,7 @@ impl TransactionTracker {
     /// Track a GETDATA message we sent to a peer
     pub fn track_getdata(&self, peer_id: u64, txid: TxId) {
         if let Ok(mut inner) = self.inner.lock() {
-            let peer_state = inner
-                .peer_states
-                .entry(peer_id)
-                .or_insert_with(|| PeerTxState::new(String::new()));
+            let peer_state = inner.peer_states.entry(peer_id).or_default();
             peer_state.add_getdata(txid);
         }
     }

--- a/tools/metrics/src/tx_tracker.rs
+++ b/tools/metrics/src/tx_tracker.rs
@@ -111,22 +111,22 @@ impl PeerTxState {
 
 /// Main transaction tracker with thread-safe access
 #[derive(Debug, Clone)]
-pub struct TransactionTracker {
-    inner: Arc<Mutex<TransactionTrackerInner>>,
+pub struct TxRelayTracker {
+    inner: Arc<Mutex<TxRelayTrackerInner>>,
 }
 
 #[derive(Debug)]
-struct TransactionTrackerInner {
+struct TxRelayTrackerInner {
     /// Per-peer tracking state
     peer_states: HashMap<u64, PeerTxState>,
     /// Last cleanup time
     last_cleanup: Instant,
 }
 
-impl TransactionTracker {
+impl TxRelayTracker {
     pub fn new() -> Self {
         Self {
-            inner: Arc::new(Mutex::new(TransactionTrackerInner {
+            inner: Arc::new(Mutex::new(TxRelayTrackerInner {
                 peer_states: HashMap::new(),
                 last_cleanup: Instant::now(),
             })),
@@ -302,7 +302,7 @@ impl TransactionTracker {
     }
 }
 
-impl TransactionTrackerInner {
+impl TxRelayTrackerInner {
     /// Force cleanup of old data
     fn cleanup_old_data(&mut self) {
         let cutoff_age = Instant::now() - PEER_TIMEOUT;
@@ -328,7 +328,7 @@ mod tests {
 
     #[test]
     fn test_unsolicited_detection() {
-        let tracker = TransactionTracker::new();
+        let tracker = TxRelayTracker::new();
         let peer_id = 1;
         let txid = TxId::from_txid(b"test_txid".to_vec());
         let wtxid = TxId::from_wtxid(b"test_wtxid".to_vec());
@@ -340,7 +340,7 @@ mod tests {
 
     #[test]
     fn test_solicited_detection() {
-        let tracker = TransactionTracker::new();
+        let tracker = TxRelayTracker::new();
         let peer_id = 1;
         let txid = TxId::from_txid(b"test_txid".to_vec());
         let wtxid = TxId::from_wtxid(b"test_wtxid".to_vec());
@@ -355,7 +355,7 @@ mod tests {
 
     #[test]
     fn test_unannounced_detection() {
-        let tracker = TransactionTracker::new();
+        let tracker = TxRelayTracker::new();
         let peer_id = 1;
         let txid = TxId::from_txid(b"test_txid".to_vec());
         let wtxid = TxId::from_wtxid(b"test_wtxid".to_vec());
@@ -367,7 +367,7 @@ mod tests {
 
     #[test]
     fn test_announced_detection() {
-        let tracker = TransactionTracker::new();
+        let tracker = TxRelayTracker::new();
         let peer_id = 1;
         let txid = TxId::from_txid(b"test_txid".to_vec());
         let wtxid = TxId::from_wtxid(b"test_wtxid".to_vec());
@@ -382,7 +382,7 @@ mod tests {
 
     #[test]
     fn test_memory_limits() {
-        let tracker = TransactionTracker::new();
+        let tracker = TxRelayTracker::new();
         let peer_id = 1;
 
         // Add more than the limit
@@ -397,7 +397,7 @@ mod tests {
 
     #[test]
     fn test_peer_cleanup() {
-        let tracker = TransactionTracker::new();
+        let tracker = TxRelayTracker::new();
         let peer_id = 1;
         let txid = TxId::from_txid(b"test_txid".to_vec());
 


### PR DESCRIPTION
- Add TransactionTracker with memory-bounded peer state tracking
- Track `INV`, `GETDATA`, and `TX` messages for unsolicited/unannounced detection
- Add per-peer metrics: `tx_unsolicited_by_peer`, `tx_unannounced_by_peer`, `tx_peer_last_activity`
- Implement peer cleanup after 30min inactivity (1000 txs/peer limit)
- Use dependency injection pattern with `Optional<&TransactionTracker>`
- Enable per-peer transaction behaviour analysis in Grafana
- Zero overhead when `tx_tracker` is None, easy testing and disabling