### PR TITLE
fix(metrics): use OS-assigned port to fix intermittent test failures

### DIFF
--- a/shared/src/metricserver.rs
+++ b/shared/src/metricserver.rs
@@ -15,7 +15,10 @@ const LOG_TARGET: &str = "metricserver";
 // This is a minimal, per request thread spawning, and incorrect HTTP server
 // which answers on all request methods with prometheus formatted metrics.
 
-pub fn start(prometheus_address: &str, registry: Option<Registry>) -> Result<(), io::Error> {
+pub fn start(
+    prometheus_address: &str,
+    registry: Option<Registry>,
+) -> Result<std::net::SocketAddr, io::Error> {
     let listener = TcpListener::bind(prometheus_address)?;
     let local_addr = listener.local_addr()?;
     log::info!(
@@ -42,7 +45,7 @@ pub fn start(prometheus_address: &str, registry: Option<Registry>) -> Result<(),
             };
         }
     });
-    Ok(())
+    Ok(local_addr)
 }
 
 fn handle_request(

--- a/shared/src/testing/nats_publisher.rs
+++ b/shared/src/testing/nats_publisher.rs
@@ -19,4 +19,13 @@ impl NatsPublisherForTesting {
             .await
             .expect("should be able to publish");
     }
+
+    /// Flush the NATS client connection, ensuring all published messages have
+    /// been received by the server (PING/PONG round-trip).
+    pub async fn flush(&self) {
+        self.client
+            .flush()
+            .await
+            .expect("should be able to flush NATS client");
+    }
 }

--- a/tools/connectivity-check/src/main.rs
+++ b/tools/connectivity-check/src/main.rs
@@ -325,8 +325,8 @@ async fn main() {
     let (input_sender, input_receiver) = unbounded();
     let (output_sender, output_receiver) = unbounded();
 
-    metricserver::start(&args.metrics_address, None).unwrap();
-    log::info!("metrics-server started on {}", &args.metrics_address);
+    let metrics_addr = metricserver::start(&args.metrics_address, None).unwrap();
+    log::info!("metrics-server started on {}", metrics_addr);
 
     let nc = nats_util::prepare_connection(&args.nats)
         .expect("should be able to open a password file")

--- a/tools/metrics/src/error.rs
+++ b/tools/metrics/src/error.rs
@@ -1,4 +1,5 @@
 use shared::async_nats;
+use shared::async_nats::client::FlushErrorKind;
 use shared::async_nats::ConnectErrorKind;
 use shared::log::SetLoggerError;
 use shared::prost::DecodeError;
@@ -13,6 +14,7 @@ pub enum RuntimeError {
     ProtobufDecode(DecodeError),
     NatsSubscribe(async_nats::client::SubscribeError),
     NatsConnect(shared::async_nats::error::Error<ConnectErrorKind>),
+    NatsFlush(shared::async_nats::error::Error<FlushErrorKind>),
 }
 
 impl fmt::Display for RuntimeError {
@@ -23,6 +25,7 @@ impl fmt::Display for RuntimeError {
             RuntimeError::ProtobufDecode(e) => write!(f, "protobuf decode error {}", e),
             RuntimeError::NatsSubscribe(e) => write!(f, "NATS subscribe error {}", e),
             RuntimeError::NatsConnect(e) => write!(f, "NATS connection error {}", e),
+            RuntimeError::NatsFlush(e) => write!(f, "NATS flush error {}", e),
         }
     }
 }
@@ -35,6 +38,7 @@ impl error::Error for RuntimeError {
             RuntimeError::ProtobufDecode(ref e) => Some(e),
             RuntimeError::NatsSubscribe(ref e) => Some(e),
             RuntimeError::NatsConnect(ref e) => Some(e),
+            RuntimeError::NatsFlush(ref e) => Some(e),
         }
     }
 }
@@ -66,5 +70,11 @@ impl From<async_nats::client::SubscribeError> for RuntimeError {
 impl From<shared::async_nats::error::Error<ConnectErrorKind>> for RuntimeError {
     fn from(e: shared::async_nats::error::Error<ConnectErrorKind>) -> Self {
         RuntimeError::NatsConnect(e)
+    }
+}
+
+impl From<shared::async_nats::error::Error<FlushErrorKind>> for RuntimeError {
+    fn from(e: shared::async_nats::error::Error<FlushErrorKind>) -> Self {
+        RuntimeError::NatsFlush(e)
     }
 }

--- a/tools/metrics/src/lib.rs
+++ b/tools/metrics/src/lib.rs
@@ -96,10 +96,12 @@ pub async fn run(
         .await?;
     info!("Connected to NATS-server at {}", args.nats.address);
     let mut sub = nc.subscribe("*").await?;
+    // Flush guarantees the server has processed our SUB command, so any
+    // events published after this point will be delivered to us.
+    nc.flush().await?;
 
     // Notify the caller of the actual bound address only after the NATS
-    // subscription is ready.  This ensures that any events published after
-    // receiving the address will be picked up by the subscription.
+    // subscription is confirmed server-side.
     if let Some(tx) = bound_addr_tx {
         let _ = tx.send(local_addr);
     }

--- a/tools/metrics/src/lib.rs
+++ b/tools/metrics/src/lib.rs
@@ -31,6 +31,7 @@ use shared::{async_nats, clap};
 use std::cmp::{max, min};
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 pub mod error;
 mod metrics;
@@ -57,14 +58,25 @@ pub struct Args {
     /// are "trace", "debug", "info", "warn", "error". See https://docs.rs/log/latest/log/enum.Level.html
     #[arg(short, long, default_value_t = Level::Debug)]
     pub log_level: Level,
+
+    /// NATS subject to subscribe to.
+    /// Defaults to '*' to keep current behavior.
+    #[arg(long, default_value = "*")]
+    pub nats_subject: String,
 }
 
 impl Args {
-    pub fn new(nats: NatsArgs, metrics_address: String, log_level: Level) -> Self {
+    pub fn new(
+        nats: NatsArgs,
+        metrics_address: String,
+        log_level: Level,
+        nats_subject: String,
+    ) -> Self {
         Self {
             nats,
             metrics_address,
             log_level,
+            nats_subject,
         }
     }
 }
@@ -91,21 +103,58 @@ pub async fn run(
 
     let local_addr = metricserver::start(&args.metrics_address, Some(metrics.registry.clone()))?;
 
-    let nc = nats_util::prepare_connection(&args.nats)?
-        .connect(&args.nats.address)
-        .await?;
+    let mut connect_options = nats_util::prepare_connection(&args.nats)?;
+    #[cfg(feature = "nats_integration_tests")]
+    {
+        // Tests can create heavy short-lived bursts.
+        connect_options = connect_options.subscription_capacity(1024 * 1024);
+    }
+
+    let nc = connect_options.connect(&args.nats.address).await?;
     info!("Connected to NATS-server at {}", args.nats.address);
-    let mut sub = nc.subscribe("*").await?;
+    let mut sub = nc.subscribe(args.nats_subject.clone()).await?;
     // Flush guarantees the server has processed our SUB command, so any
     // events published after this point will be delivered to us.
     nc.flush().await?;
+
+    #[cfg(feature = "nats_integration_tests")]
+    {
+        // Validate end-to-end delivery for this exact subscription before
+        // signaling test readiness.
+        let ready_marker = format!("__metrics_ready__{}", util::current_timestamp()).into_bytes();
+        nc.publish(args.nats_subject.clone(), ready_marker.clone().into())
+            .await
+            .expect("metrics readiness publish should succeed");
+        nc.flush()
+            .await
+            .expect("metrics readiness flush should succeed");
+
+        let deadline = shared::tokio::time::Instant::now() + Duration::from_secs(2);
+        loop {
+            let maybe_msg = shared::tokio::time::timeout(Duration::from_millis(200), sub.next())
+                .await
+                .expect("timed out waiting for metrics readiness marker");
+            if let Some(msg) = maybe_msg {
+                if msg.payload.as_ref() == ready_marker.as_slice() {
+                    break;
+                }
+                // Ignore non-marker messages that may arrive in unusual
+                // ordering scenarios prior to test readiness.
+            } else {
+                panic!("subscription ended before metrics readiness marker");
+            }
+
+            if shared::tokio::time::Instant::now() >= deadline {
+                panic!("did not receive metrics readiness marker in time");
+            }
+        }
+    }
 
     // Notify the caller of the actual bound address only after the NATS
     // subscription is confirmed server-side.
     if let Some(tx) = bound_addr_tx {
         let _ = tx.send(local_addr);
     }
-
     metrics
         .runtime_start_timestamp
         .set(util::current_timestamp() as i64);

--- a/tools/metrics/src/lib.rs
+++ b/tools/metrics/src/lib.rs
@@ -131,20 +131,16 @@ pub async fn run(
 
         let deadline = shared::tokio::time::Instant::now() + Duration::from_secs(2);
         loop {
-            let maybe_msg = match shared::tokio::time::timeout(
-                Duration::from_millis(200),
-                sub.next(),
-            )
-            .await
-            {
-                Ok(msg) => msg,
-                Err(_) => {
-                    if shared::tokio::time::Instant::now() >= deadline {
-                        panic!("did not receive metrics readiness marker in time");
+            let maybe_msg =
+                match shared::tokio::time::timeout(Duration::from_millis(200), sub.next()).await {
+                    Ok(msg) => msg,
+                    Err(_) => {
+                        if shared::tokio::time::Instant::now() >= deadline {
+                            panic!("did not receive metrics readiness marker in time");
+                        }
+                        continue;
                     }
-                    continue;
-                }
-            };
+                };
             if let Some(msg) = maybe_msg {
                 if msg.payload.as_ref() == ready_marker.as_slice() {
                     break;

--- a/tools/metrics/src/lib.rs
+++ b/tools/metrics/src/lib.rs
@@ -107,7 +107,7 @@ pub async fn run(
     #[cfg(feature = "nats_integration_tests")]
     {
         // Tests can create heavy short-lived bursts.
-        connect_options = connect_options.subscription_capacity(1024 * 1024);
+        connect_options = connect_options.subscription_capacity(64 * 1024);
     }
 
     let nc = connect_options.connect(&args.nats.address).await?;
@@ -131,9 +131,20 @@ pub async fn run(
 
         let deadline = shared::tokio::time::Instant::now() + Duration::from_secs(2);
         loop {
-            let maybe_msg = shared::tokio::time::timeout(Duration::from_millis(200), sub.next())
-                .await
-                .expect("timed out waiting for metrics readiness marker");
+            let maybe_msg = match shared::tokio::time::timeout(
+                Duration::from_millis(200),
+                sub.next(),
+            )
+            .await
+            {
+                Ok(msg) => msg,
+                Err(_) => {
+                    if shared::tokio::time::Instant::now() >= deadline {
+                        panic!("did not receive metrics readiness marker in time");
+                    }
+                    continue;
+                }
+            };
             if let Some(msg) = maybe_msg {
                 if msg.payload.as_ref() == ready_marker.as_slice() {
                     break;

--- a/tools/metrics/src/lib.rs
+++ b/tools/metrics/src/lib.rs
@@ -24,6 +24,7 @@ use shared::protobuf::{
     p2p_extractor::p2p,
     rpc_extractor::{rpc, Addrman, AddrmanBucket},
 };
+use shared::tokio::sync::oneshot;
 use shared::tokio::sync::watch;
 use shared::util::{self, is_on_linkinglion_banlist};
 use shared::{async_nats, clap};
@@ -82,18 +83,26 @@ struct State {
 pub async fn run(
     args: Args,
     mut shutdown_rx: watch::Receiver<bool>,
+    bound_addr_tx: Option<oneshot::Sender<std::net::SocketAddr>>,
 ) -> Result<(), error::RuntimeError> {
     info!(target: LOG_TARGET, "Starting metrics-server...",);
 
     let metrics = metrics::Metrics::new();
 
-    metricserver::start(&args.metrics_address, Some(metrics.registry.clone()))?;
+    let local_addr = metricserver::start(&args.metrics_address, Some(metrics.registry.clone()))?;
 
     let nc = nats_util::prepare_connection(&args.nats)?
         .connect(&args.nats.address)
         .await?;
     info!("Connected to NATS-server at {}", args.nats.address);
     let mut sub = nc.subscribe("*").await?;
+
+    // Notify the caller of the actual bound address only after the NATS
+    // subscription is ready.  This ensures that any events published after
+    // receiving the address will be picked up by the subscription.
+    if let Some(tx) = bound_addr_tx {
+        let _ = tx.send(local_addr);
+    }
 
     metrics
         .runtime_start_timestamp

--- a/tools/metrics/src/main.rs
+++ b/tools/metrics/src/main.rs
@@ -12,7 +12,9 @@ async fn main() {
     }
 
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
-    let metrics_handle = tokio::spawn(metrics::run(args, shutdown_rx));
+    // No bound address notification needed in production (used in tests to
+    // communicate the OS-assigned port back when binding to port 0).
+    let metrics_handle = tokio::spawn(metrics::run(args, shutdown_rx, None));
 
     tokio::select! {
         _ = signal::ctrl_c() => {

--- a/tools/metrics/tests/integration.rs
+++ b/tools/metrics/tests/integration.rs
@@ -1,10 +1,9 @@
 #![cfg(feature = "nats_integration_tests")]
 
-use metrics::error::RuntimeError;
 use metrics::Args;
 
 use shared::{
-    log::{debug, warn, Level, LevelFilter},
+    log::{debug, Level, LevelFilter},
     nats_subjects::Subject,
     nats_util::NatsArgs,
     prost::Message,
@@ -34,12 +33,11 @@ use shared::{
             NetworkInfoNetwork, OrphanTx, OrphanTxs, PeerInfo, PeerInfos, UploadTarget,
         },
     },
-    rand::{self, Rng},
     simple_logger::SimpleLogger,
     testing::{nats_publisher::NatsPublisherForTesting, nats_server::NatsServerForTesting},
     tokio::{
-        self,
-        sync::{watch, Mutex},
+        self, select,
+        sync::{oneshot, watch},
         time::sleep,
     },
     util::current_timestamp,
@@ -47,41 +45,21 @@ use shared::{
 
 use std::{
     collections::HashMap,
-    io::ErrorKind,
     io::{Read, Write},
     net::TcpStream,
-    sync::{
-        atomic::{AtomicU16, Ordering},
-        Arc, Once, OnceLock,
-    },
+    sync::Once,
     time::Duration,
 };
 
 static INIT: Once = Once::new();
-static NEXT_METRICS_PORT: OnceLock<AtomicU16> = OnceLock::new();
 
-fn setup() -> u16 {
+fn setup() {
     INIT.call_once(|| {
         SimpleLogger::new()
             .with_level(LevelFilter::Trace)
             .init()
             .unwrap();
-
-        let mut rng = rand::rng();
-
-        // choose start ports from the ephemeral port range
-        let metrics_start = rng.random_range(49152..65500);
-
-        NEXT_METRICS_PORT
-            .set(AtomicU16::new(metrics_start))
-            .unwrap();
     });
-
-    let metrics_port = NEXT_METRICS_PORT
-        .get()
-        .unwrap()
-        .fetch_add(1, Ordering::SeqCst);
-    metrics_port
 }
 
 fn make_test_args(nats_port: u16, metrics_port: u16) -> Args {
@@ -150,47 +128,32 @@ fn check_metrics(port: u16, expected: &[&str]) -> Result<bool, std::io::Error> {
 }
 
 async fn publish_and_check(events: &[Event], subject: Subject, expected: &str) {
-    let initial_metrics_port = setup();
-    let metrics_port: Arc<Mutex<u16>> = Arc::new(Mutex::new(initial_metrics_port));
+    setup();
 
     let nats_server = NatsServerForTesting::new(&[]).await;
     let nats_publisher = NatsPublisherForTesting::new(nats_server.port).await;
 
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
-    let metrics_port_clone = metrics_port.clone();
-    let metrics_handle = tokio::spawn(async move {
-        loop {
-            let port: u16;
-            {
-                port = *metrics_port_clone.lock().await;
-            }
+    let (addr_tx, addr_rx) = oneshot::channel();
 
-            let args = make_test_args(nats_server.port, port);
-            match metrics::run(args, shutdown_rx.clone()).await {
-                Ok(_) => break,
-                Err(e) => match e {
-                    RuntimeError::Io(e) => match e.kind() {
-                        ErrorKind::AddrInUse => {
-                            let new_port = NEXT_METRICS_PORT
-                                .get()
-                                .unwrap()
-                                .fetch_add(1, Ordering::SeqCst);
-                            warn!(
-                                "Port {} seems to be already in use. Trying port {} next..",
-                                port, new_port
-                            );
-                            let mut port = metrics_port_clone.lock().await;
-                            *port = new_port;
-                        }
-                        _ => panic!("Couldn not start metrics tool: {}", e),
-                    },
-                    _ => panic!("Couldn not start metrics tool: {}", e),
-                },
-            }
-        }
+    let mut metrics_handle = tokio::spawn(async move {
+        let args = make_test_args(nats_server.port, 0);
+        metrics::run(args, shutdown_rx.clone(), Some(addr_tx))
+            .await
+            .expect("metrics tool failed");
     });
-    // allow the metrics tool to start
-    sleep(Duration::from_secs(1)).await;
+
+    // Wait for the metrics tool to bind and report its actual port.
+    // We race against the task handle so that if the tool fails
+    // before binding (e.g. NATS connection error), we surface the
+    // real error instead of a generic "channel closed" panic.
+    let metrics_port = select! {
+        addr = addr_rx => addr.expect("metrics tool should send bound address").port(),
+        result = &mut metrics_handle => {
+            result.unwrap();  // propagates the task's panic (with its message)
+            unreachable!("metrics task exited before sending bound address");
+        }
+    };
 
     for event in events {
         debug!("publishing: {:?}", event);
@@ -202,8 +165,7 @@ async fn publish_and_check(events: &[Event], subject: Subject, expected: &str) {
     sleep(Duration::from_millis(100)).await;
 
     let expected_lines: Vec<&str> = expected.split('\n').collect();
-    let port = metrics_port.lock().await;
-    assert!(check_metrics(*port, &expected_lines).expect("Could not fetch metrics"));
+    assert!(check_metrics(metrics_port, &expected_lines).expect("Could not fetch metrics"));
 
     shutdown_tx.send(true).unwrap();
     metrics_handle.await.unwrap();
@@ -212,11 +174,11 @@ async fn publish_and_check(events: &[Event], subject: Subject, expected: &str) {
 #[tokio::test]
 async fn test_integration_metrics_no_nats_connection() {
     println!("test that we fail if we can't connect to NATS (due to port 0)");
-    let _ = setup();
+    setup();
 
     let args = make_test_args(0, 0);
     let (_, shutdown_rx) = watch::channel(false);
-    let result = metrics::run(args, shutdown_rx).await;
+    let result = metrics::run(args, shutdown_rx, None).await;
 
     assert!(result.is_err());
     // allows for easier debugging if it's not a Io error..

--- a/tools/metrics/tests/integration.rs
+++ b/tools/metrics/tests/integration.rs
@@ -36,7 +36,10 @@ use shared::{
     simple_logger::SimpleLogger,
     testing::{nats_publisher::NatsPublisherForTesting, nats_server::NatsServerForTesting},
     tokio::{
-        self, select,
+        self,
+        io::{AsyncReadExt, AsyncWriteExt},
+        net::TcpStream,
+        select,
         sync::{oneshot, watch},
         time::sleep,
     },
@@ -45,13 +48,19 @@ use shared::{
 
 use std::{
     collections::HashMap,
-    io::{Read, Write},
-    net::TcpStream,
-    sync::Once,
+    sync::{LazyLock, Once},
     time::Duration,
 };
 
 static INIT: Once = Once::new();
+
+/// Limit concurrent test execution. Each test spawns its own nats-server
+/// process, an HTTP metrics server, and NATS client connections. Running all
+/// 55 tests simultaneously overwhelms the system — nats-server processes
+/// become unresponsive under CPU contention, causing events to never be
+/// delivered even with generous polling timeouts.
+static TEST_SEMAPHORE: LazyLock<shared::tokio::sync::Semaphore> =
+    LazyLock::new(|| shared::tokio::sync::Semaphore::new(2));
 
 fn setup() {
     INIT.call_once(|| {
@@ -75,43 +84,36 @@ fn make_test_args(nats_port: u16, metrics_port: u16) -> Args {
     )
 }
 
-fn fetch_metrics(port: u16) -> Result<String, std::io::Error> {
+async fn fetch_metrics(port: u16) -> Result<String, std::io::Error> {
     let addr = format!("127.0.0.1:{}", port);
     debug!("fetching metrics from {}", addr);
-    let mut stream = TcpStream::connect(addr.clone())?;
-    stream.set_read_timeout(Some(Duration::from_secs(5)))?;
-    stream.set_write_timeout(Some(Duration::from_secs(5)))?;
+    let mut stream = tokio::time::timeout(Duration::from_secs(5), TcpStream::connect(addr.clone()))
+        .await
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::TimedOut, e))??;
 
     let request = format!(
         "GET / HTTP/1.1\r\nHost: {}\r\nConnection: close\r\n\r\n",
         addr
     );
 
-    stream.write_all(request.as_bytes()).unwrap();
-    stream.flush()?;
+    tokio::time::timeout(Duration::from_secs(5), stream.write_all(request.as_bytes()))
+        .await
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::TimedOut, e))??;
+    tokio::time::timeout(Duration::from_secs(5), stream.flush())
+        .await
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::TimedOut, e))??;
 
     // Read the full response until EOF (server closes the connection).
     let mut response = Vec::new();
-    let mut s = stream;
-    s.read_to_end(&mut response)?;
+    tokio::time::timeout(Duration::from_secs(5), stream.read_to_end(&mut response))
+        .await
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::TimedOut, e))??;
 
     Ok(String::from_utf8_lossy(&response).to_string())
 }
 
-fn check_metrics(port: u16, expected: &[&str]) -> Result<bool, std::io::Error> {
-    let metrics_raw = fetch_metrics(port)?;
-
-    println!("HTTP response from metrics server:\n");
-    for line in metrics_raw.split("\n") {
-        println!("{}", line);
-    }
-
-    println!("Only metrics (no help text):\n");
-    for line in metrics_raw.split("\n") {
-        if !line.starts_with("# ") {
-            println!("{}", line);
-        }
-    }
+async fn check_metrics(port: u16, expected: &[&str]) -> Result<bool, std::io::Error> {
+    let metrics_raw = fetch_metrics(port).await?;
 
     let mut no_lines_missing = true;
     for line in expected {
@@ -120,7 +122,7 @@ fn check_metrics(port: u16, expected: &[&str]) -> Result<bool, std::io::Error> {
             continue;
         }
         if !metrics_raw.contains(line) {
-            println!("Response does not contain line: '{}'", line);
+            debug!("response does not contain line: '{}'", line);
             no_lines_missing = false;
         }
     }
@@ -130,6 +132,7 @@ fn check_metrics(port: u16, expected: &[&str]) -> Result<bool, std::io::Error> {
 async fn publish_and_check(events: &[Event], subject: Subject, expected: &str) {
     setup();
 
+    let _permit = TEST_SEMAPHORE.acquire().await.expect("semaphore closed");
     let nats_server = NatsServerForTesting::new(&[]).await;
     let nats_publisher = NatsPublisherForTesting::new(nats_server.port).await;
 
@@ -162,16 +165,63 @@ async fn publish_and_check(events: &[Event], subject: Subject, expected: &str) {
             .await;
     }
 
-    sleep(Duration::from_millis(100)).await;
+    // Flush guarantees the NATS server has received all published messages
+    // (PING/PONG round-trip). Without this, `publish()` only queues the
+    // message in the client buffer — the server may not have forwarded it
+    // to subscribers yet.
+    nats_publisher.flush().await;
 
     let expected_lines: Vec<&str> = expected.split('\n').collect();
-    assert!(check_metrics(metrics_port, &expected_lines).expect("Could not fetch metrics"));
+
+    // Poll until the metrics tool has processed the published events.
+    // The NATS pub/sub pipeline has variable latency (server forwarding,
+    // subscriber processing, Prometheus registry update), so a fixed sleep
+    // is inherently racy. Instead we retry with short intervals.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    let mut attempts = 0u32;
+    loop {
+        attempts += 1;
+
+        if metrics_handle.is_finished() {
+            // Surface the real task failure instead of timing out on stale metrics.
+            metrics_handle
+                .await
+                .expect("metrics task should not panic before convergence");
+            panic!("metrics task exited before metrics convergence");
+        }
+
+        match check_metrics(metrics_port, &expected_lines).await {
+            Ok(true) => break,
+            Ok(false) if tokio::time::Instant::now() < deadline => {
+                sleep(Duration::from_millis(50)).await;
+            }
+            Ok(false) => {
+                let metrics_raw = fetch_metrics(metrics_port)
+                    .await
+                    .unwrap_or_else(|e| format!("failed to fetch metrics on final attempt: {e}"));
+                panic!(
+                    "Metrics did not converge within timeout after {attempts} attempts. \
+                     Expected lines:\n{expected}\n\
+                     Final metrics response:\n{metrics_raw}",
+                );
+            }
+            Err(e) if tokio::time::Instant::now() < deadline => {
+                debug!("check_metrics transient error (attempt {attempts}): {e}");
+                sleep(Duration::from_millis(50)).await;
+            }
+            Err(e) => {
+                panic!(
+                    "Could not fetch metrics after {attempts} attempts: {e}",
+                );
+            }
+        }
+    }
 
     shutdown_tx.send(true).unwrap();
     metrics_handle.await.unwrap();
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_integration_metrics_no_nats_connection() {
     println!("test that we fail if we can't connect to NATS (due to port 0)");
     setup();
@@ -191,7 +241,7 @@ async fn test_integration_metrics_no_nats_connection() {
     ))
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_integration_metrics_basic() {
     println!("test that we can connect to NATS and query from the metrics server");
 
@@ -203,7 +253,7 @@ async fn test_integration_metrics_basic() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_integration_metrics_p2p_message_count() {
     println!("test that the P2P message count works");
 
@@ -249,7 +299,7 @@ async fn test_integration_metrics_p2p_message_count() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_integration_metrics_p2p_traffic_linkinglion() {
     println!("test that the linkinglion traffic P2P metrics work");
 
@@ -299,7 +349,7 @@ async fn test_integration_metrics_p2p_traffic_linkinglion() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_integration_metrics_p2p_addr() {
     println!("test that the P2P addr metrics work");
 
@@ -513,7 +563,7 @@ async fn test_integration_metrics_p2p_addr() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_integration_metrics_p2p_addrv2() {
     println!("test that the P2P addrv2 metrics work");
 
@@ -719,7 +769,7 @@ async fn test_integration_metrics_p2p_addrv2() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_integration_metrics_p2p_address_self_announcement() {
     println!("test that the P2P address self-announcement metric works");
 
@@ -805,7 +855,7 @@ async fn test_integration_metrics_p2p_address_self_announcement() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_integration_metrics_p2p_address_subnet_announcement() {
     println!("test that the P2P address subnet-announcement metric works");
 
@@ -891,7 +941,7 @@ async fn test_integration_metrics_p2p_address_subnet_announcement() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_integration_metrics_p2p_version() {
     println!("test that the P2P version metrics work");
 
@@ -991,7 +1041,7 @@ async fn test_integration_metrics_p2p_version() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_integration_metrics_p2p_feefilter() {
     println!("test that the P2P feefilter metrics work");
 
@@ -1022,7 +1072,7 @@ async fn test_integration_metrics_p2p_feefilter() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_integration_metrics_p2p_rejected() {
     println!("test that the P2P rejected metrics work");
 
@@ -1076,7 +1126,7 @@ async fn test_integration_metrics_p2p_rejected() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_integration_metrics_p2p_inv() {
     println!("test that the P2P inv metrics work");
 
@@ -1195,7 +1245,7 @@ async fn test_integration_metrics_p2p_inv() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_integration_metrics_p2p_inv_large_outbound() {
     println!("test that large outbound INV message (> 35) metrics work");
 
@@ -1278,7 +1328,7 @@ async fn test_integration_metrics_p2p_inv_large_outbound() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_integration_metrics_p2p_oldping() {
     println!("test that the P2P oldping metrics work");
 
@@ -1307,7 +1357,7 @@ async fn test_integration_metrics_p2p_oldping() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_integration_metrics_p2p_ping_value() {
     println!("test that the P2P ping value metrics work");
 
@@ -1361,7 +1411,7 @@ async fn test_integration_metrics_p2p_ping_value() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_integration_metrics_p2p_empty_addrv2() {
     println!("test that the P2P emptyaddrv2 metrics work");
 
@@ -1390,7 +1440,7 @@ async fn test_integration_metrics_p2p_empty_addrv2() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_integration_metrics_conn_inbound() {
     println!("test that the inbound connection metrics work");
 
@@ -1421,7 +1471,7 @@ async fn test_integration_metrics_conn_inbound() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_integration_metrics_conn_outbound() {
     println!("test that the outbound connection metrics work");
 
@@ -1453,7 +1503,7 @@ async fn test_integration_metrics_conn_outbound() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_integration_metrics_conn_closed() {
     println!("test that the closed connection metrics work");
 
@@ -1486,7 +1536,7 @@ async fn test_integration_metrics_conn_closed() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_integration_metrics_conn_inbound_evicted() {
     println!("test that the inbound_evicted connection metrics work");
 
@@ -1517,7 +1567,7 @@ async fn test_integration_metrics_conn_inbound_evicted() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_integration_metrics_conn_misbehaving() {
     println!("test that the misbehaving connection metrics work");
 
@@ -1542,7 +1592,7 @@ async fn test_integration_metrics_conn_misbehaving() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_integration_metrics_conn_special_ip() {
     println!("test that the metrics for special IPs work");
 
@@ -1613,7 +1663,7 @@ async fn test_integration_metrics_conn_special_ip() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_integration_metrics_conn_private_transaction_broadcast() {
     println!("test that the private_transaction_broadcast connection metrics work");
 
@@ -1660,7 +1710,7 @@ async fn test_integration_metrics_conn_private_transaction_broadcast() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_integration_metrics_validation() {
     println!("test that validation metrics work");
 
@@ -1693,7 +1743,7 @@ async fn test_integration_metrics_validation() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_integration_metrics_mempool_added() {
     println!("test that the mempool added metrics work");
 
@@ -1717,7 +1767,7 @@ async fn test_integration_metrics_mempool_added() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_integration_metrics_mempool_added_mass() {
     println!("test that the mempool added metrics work when we add a lot of events");
 
@@ -1747,7 +1797,7 @@ async fn test_integration_metrics_mempool_added_mass() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_integration_metrics_mempool_replaced() {
     println!("test that the mempool replaced metrics work");
 
@@ -1776,7 +1826,7 @@ async fn test_integration_metrics_mempool_replaced() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_integration_metrics_mempool_rejected() {
     println!("test that the mempool rejected metrics work");
 
@@ -1809,7 +1859,7 @@ async fn test_integration_metrics_mempool_rejected() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_integration_metrics_mempool_removed() {
     println!("test that the mempool removed metrics work");
 
@@ -1849,7 +1899,7 @@ async fn test_integration_metrics_mempool_removed() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_integration_metrics_rpc_peerinfo() {
     println!("test that the RPC peer-info metrics work");
 
@@ -2025,7 +2075,7 @@ async fn test_integration_metrics_rpc_peerinfo() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_integration_metrics_addrman() {
     println!("test that the addrman metrics work");
 
@@ -2068,7 +2118,7 @@ async fn test_integration_metrics_addrman() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_integration_metrics_rpc_peerinfo_sub1satvbyte() {
     println!("test that the sub-1 sat/vbyte peers metric works");
 
@@ -2223,7 +2273,7 @@ async fn test_integration_metrics_rpc_peerinfo_sub1satvbyte() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_integration_metrics_rpc_peerinfo_invtosend() {
     println!("test that the invtosend metrics work");
 
@@ -2377,7 +2427,7 @@ async fn test_integration_metrics_rpc_peerinfo_invtosend() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_integration_metrics_rpc_peerinfo_cpuload() {
     println!("test that the cpuload metrics work");
 
@@ -2531,7 +2581,7 @@ async fn test_integration_metrics_rpc_peerinfo_cpuload() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_integration_metrics_rpc_peerinfo_ipv4_inbound_diversity() {
     println!("test that the ipv4 inbound diversity metric works");
 
@@ -2679,7 +2729,7 @@ async fn test_integration_metrics_rpc_peerinfo_ipv4_inbound_diversity() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_integration_metrics_rpc_peerinfo_peer_list_bitprojects() {
     println!("test that the bitprojects in/outbound peers metric works");
 
@@ -2828,7 +2878,7 @@ async fn test_integration_metrics_rpc_peerinfo_peer_list_bitprojects() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_integration_metrics_rpc_uptime() {
     println!("test that the uptime metric works");
 
@@ -2847,7 +2897,7 @@ async fn test_integration_metrics_rpc_uptime() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_integration_metrics_rpc_getnettotals() {
     println!("test that the getnettotal metrics work");
 
@@ -2880,7 +2930,7 @@ async fn test_integration_metrics_rpc_getnettotals() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_integration_metrics_rpc_getmemoryinfo() {
     println!("test that the getmemoryinfo metrics work");
 
@@ -2911,7 +2961,7 @@ async fn test_integration_metrics_rpc_getmemoryinfo() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_integration_metrics_rpc_mempoolinfo() {
     println!("test that the mempoolinfo metrics work");
 
@@ -2950,7 +3000,7 @@ async fn test_integration_metrics_rpc_mempoolinfo() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_integration_metrics_rpc_getaddrmaninfo() {
     println!("test that the addrmaninfo metrics work");
 
@@ -2994,7 +3044,7 @@ async fn test_integration_metrics_rpc_getaddrmaninfo() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_integration_metrics_rpc_chaintxstats() {
     println!("test that the chaintxstats metrics work");
 
@@ -3030,7 +3080,7 @@ async fn test_integration_metrics_rpc_chaintxstats() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_integration_metrics_rpc_getrawaddrman() {
     println!("test that the getrawaddrman metrics work");
 
@@ -3097,7 +3147,7 @@ async fn test_integration_metrics_rpc_getrawaddrman() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_integration_metrics_rpc_getrawaddrman_changes() {
     println!("test that the getrawaddrman changes (delta between curr and prev) metrics work");
 
@@ -3202,7 +3252,7 @@ async fn test_integration_metrics_rpc_getrawaddrman_changes() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_integration_metrics_p2pextractor_ping_duration() {
     println!("test that p2p-extractor ping duration metrics work");
 
@@ -3223,7 +3273,7 @@ async fn test_integration_metrics_p2pextractor_ping_duration() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_integration_metrics_p2pextractor_address_annoucement() {
     println!("test that p2p-extractor address annoucement metrics work");
 
@@ -3267,7 +3317,7 @@ async fn test_integration_metrics_p2pextractor_address_annoucement() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_integration_metrics_p2pextractor_inv_annoucement() {
     println!("test that p2p-extractor inventory annoucement metrics work");
 
@@ -3300,7 +3350,7 @@ async fn test_integration_metrics_p2pextractor_inv_annoucement() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_integration_metrics_p2pextractor_feefilter_annoucement() {
     println!("test that p2p-extractor feefilter annoucement metrics work");
 
@@ -3324,7 +3374,7 @@ async fn test_integration_metrics_p2pextractor_feefilter_annoucement() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_integration_metrics_logextractor_logevents() {
     println!("test that log-extractor log events metric work");
 
@@ -3361,7 +3411,7 @@ async fn test_integration_metrics_logextractor_logevents() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_integration_metrics_logextractor_blockconnected_events() {
     println!("test that log-extractor block connected log events metric work");
 
@@ -3417,7 +3467,7 @@ async fn test_integration_metrics_logextractor_blockconnected_events() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_integration_metrics_logextractor_blockchecked_events() {
     println!("test that log-extractor block checked log events metric work");
 
@@ -3448,7 +3498,7 @@ async fn test_integration_metrics_logextractor_blockchecked_events() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_integration_metrics_logextractor_blockchecked_mutated_events() {
     println!("test that log-extractor block checked mutated block events metric work");
 
@@ -3479,7 +3529,7 @@ async fn test_integration_metrics_logextractor_blockchecked_mutated_events() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_integration_metrics_rpc_getnetworkinfo() {
     println!("test that the getnetworkinfo metrics work");
 
@@ -3544,7 +3594,7 @@ async fn test_integration_metrics_rpc_getnetworkinfo() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_integration_metrics_rpc_getblockchaininfo() {
     println!("test that the getblockchaininfo metrics work");
 
@@ -3594,7 +3644,7 @@ async fn test_integration_metrics_rpc_getblockchaininfo() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_integration_metrics_rpc_getorphantxs() {
     println!("test that the getorphantxs metrics work");
 

--- a/tools/metrics/tests/integration.rs
+++ b/tools/metrics/tests/integration.rs
@@ -53,12 +53,11 @@ use std::{
     sync::mpsc,
     sync::{
         atomic::{AtomicU64, Ordering},
-        LazyLock,
-        Once,
+        LazyLock, Once,
     },
     thread,
-    time::Instant,
     time::Duration,
+    time::Instant,
 };
 
 static INIT: Once = Once::new();
@@ -131,11 +130,7 @@ fn spawn_shared_nats_server() -> u16 {
                 Box::leak(Box::new(child));
                 return port;
             }
-            if child
-                .try_wait()
-                .expect("try_wait should succeed")
-                .is_some()
-            {
+            if child.try_wait().expect("try_wait should succeed").is_some() {
                 break;
             }
             thread::sleep(Duration::from_millis(20));
@@ -151,10 +146,12 @@ fn spawn_shared_nats_server() -> u16 {
 async fn fetch_metrics(port: u16) -> Result<String, std::io::Error> {
     let addr = format!("127.0.0.1:{}", port);
     debug!("fetching metrics from {}", addr);
-    let mut stream =
-        tokio::time::timeout(Duration::from_secs(5), TokioTcpStream::connect(addr.clone()))
-            .await
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::TimedOut, e))??;
+    let mut stream = tokio::time::timeout(
+        Duration::from_secs(5),
+        TokioTcpStream::connect(addr.clone()),
+    )
+    .await
+    .map_err(|e| std::io::Error::new(std::io::ErrorKind::TimedOut, e))??;
 
     let request = format!(
         "GET / HTTP/1.1\r\nHost: {}\r\nConnection: close\r\n\r\n",
@@ -293,7 +290,9 @@ async fn publish_and_check(events: &[Event], subject: Subject, expected: &str) {
         Ok(Err(e)) => panic!("metrics task failed during shutdown: {e}"),
         Err(e) => panic!("metrics task did not report shutdown result: {e}"),
     }
-    metrics_thread.join().expect("metrics thread should join cleanly");
+    metrics_thread
+        .join()
+        .expect("metrics thread should join cleanly");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/tools/metrics/tests/integration.rs
+++ b/tools/metrics/tests/integration.rs
@@ -34,13 +34,12 @@ use shared::{
         },
     },
     simple_logger::SimpleLogger,
-    testing::{nats_publisher::NatsPublisherForTesting, nats_server::NatsServerForTesting},
+    testing::nats_publisher::NatsPublisherForTesting,
     tokio::{
         self,
         io::{AsyncReadExt, AsyncWriteExt},
-        net::TcpStream,
-        select,
-        sync::{oneshot, watch},
+        net::TcpStream as TokioTcpStream,
+        sync::{oneshot, watch, OnceCell},
         time::sleep,
     },
     util::current_timestamp,
@@ -48,30 +47,36 @@ use shared::{
 
 use std::{
     collections::HashMap,
-    sync::{LazyLock, Once},
+    env,
+    net::TcpStream,
+    process::{Command, Stdio},
+    sync::mpsc,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        LazyLock,
+        Once,
+    },
+    thread,
+    time::Instant,
     time::Duration,
 };
 
 static INIT: Once = Once::new();
-
-/// Limit concurrent test execution. Each test spawns its own nats-server
-/// process, an HTTP metrics server, and NATS client connections. Running all
-/// 55 tests simultaneously overwhelms the system — nats-server processes
-/// become unresponsive under CPU contention, causing events to never be
-/// delivered even with generous polling timeouts.
+static SHARED_NATS_PORT: OnceCell<u16> = OnceCell::const_new();
+static TEST_SUBJECT_SEQ: AtomicU64 = AtomicU64::new(1);
 static TEST_SEMAPHORE: LazyLock<shared::tokio::sync::Semaphore> =
     LazyLock::new(|| shared::tokio::sync::Semaphore::new(2));
 
 fn setup() {
     INIT.call_once(|| {
         SimpleLogger::new()
-            .with_level(LevelFilter::Trace)
+            .with_level(LevelFilter::Error)
             .init()
             .unwrap();
     });
 }
 
-fn make_test_args(nats_port: u16, metrics_port: u16) -> Args {
+fn make_test_args(nats_port: u16, metrics_port: u16, nats_subject: String) -> Args {
     Args::new(
         NatsArgs {
             address: format!("127.0.0.1:{}", nats_port),
@@ -80,16 +85,76 @@ fn make_test_args(nats_port: u16, metrics_port: u16) -> Args {
             password_file: None,
         },
         format!("127.0.0.1:{}", metrics_port),
-        Level::Trace,
+        Level::Error,
+        nats_subject,
     )
+}
+
+async fn shared_nats_port() -> u16 {
+    *SHARED_NATS_PORT
+        .get_or_init(|| async { spawn_shared_nats_server() })
+        .await
+}
+
+fn spawn_shared_nats_server() -> u16 {
+    let nats_server_binary_path: String = match env::var("NATS_SERVER_BINARY") {
+        Ok(b) => b,
+        Err(e) => panic!(
+            "Set NATS_SERVER_BINARY to the nats-server binary path for integration tests: {}",
+            e
+        ),
+    };
+
+    for _attempt in 1..=20 {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0")
+            .expect("should be able to reserve ephemeral TCP port");
+        let port = listener
+            .local_addr()
+            .expect("listener should have local address")
+            .port();
+        drop(listener);
+
+        let mut child = match Command::new(&nats_server_binary_path)
+            .args([format!("--port={port}"), "--addr=127.0.0.1".to_string()])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+        {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+
+        let addr = format!("127.0.0.1:{port}");
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while Instant::now() < deadline {
+            if TcpStream::connect(&addr).is_ok() {
+                Box::leak(Box::new(child));
+                return port;
+            }
+            if child
+                .try_wait()
+                .expect("try_wait should succeed")
+                .is_some()
+            {
+                break;
+            }
+            thread::sleep(Duration::from_millis(20));
+        }
+
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+
+    panic!("Could not spawn shared NATS server for integration tests")
 }
 
 async fn fetch_metrics(port: u16) -> Result<String, std::io::Error> {
     let addr = format!("127.0.0.1:{}", port);
     debug!("fetching metrics from {}", addr);
-    let mut stream = tokio::time::timeout(Duration::from_secs(5), TcpStream::connect(addr.clone()))
-        .await
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::TimedOut, e))??;
+    let mut stream =
+        tokio::time::timeout(Duration::from_secs(5), TokioTcpStream::connect(addr.clone()))
+            .await
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::TimedOut, e))??;
 
     let request = format!(
         "GET / HTTP/1.1\r\nHost: {}\r\nConnection: close\r\n\r\n",
@@ -131,37 +196,42 @@ async fn check_metrics(port: u16, expected: &[&str]) -> Result<bool, std::io::Er
 
 async fn publish_and_check(events: &[Event], subject: Subject, expected: &str) {
     setup();
-
     let _permit = TEST_SEMAPHORE.acquire().await.expect("semaphore closed");
-    let nats_server = NatsServerForTesting::new(&[]).await;
-    let nats_publisher = NatsPublisherForTesting::new(nats_server.port).await;
+
+    let nats_port = shared_nats_port().await;
+    let nats_publisher = NatsPublisherForTesting::new(nats_port).await;
+    let subject_id = TEST_SUBJECT_SEQ.fetch_add(1, Ordering::Relaxed);
+    let nats_subject = format!("{}.{}", subject, subject_id);
 
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
     let (addr_tx, addr_rx) = oneshot::channel();
+    let (metrics_done_tx, metrics_done_rx) = mpsc::channel::<Result<(), String>>();
 
-    let mut metrics_handle = tokio::spawn(async move {
-        let args = make_test_args(nats_server.port, 0);
-        metrics::run(args, shutdown_rx.clone(), Some(addr_tx))
-            .await
-            .expect("metrics tool failed");
+    let nats_subject_for_metrics = nats_subject.clone();
+    let metrics_thread = thread::spawn(move || {
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .build()
+            .expect("metrics runtime should build");
+        let args = make_test_args(nats_port, 0, nats_subject_for_metrics);
+        let result = rt
+            .block_on(async { metrics::run(args, shutdown_rx.clone(), Some(addr_tx)).await })
+            .map_err(|e| e.to_string());
+        let _ = metrics_done_tx.send(result);
     });
 
     // Wait for the metrics tool to bind and report its actual port.
-    // We race against the task handle so that if the tool fails
-    // before binding (e.g. NATS connection error), we surface the
-    // real error instead of a generic "channel closed" panic.
-    let metrics_port = select! {
-        addr = addr_rx => addr.expect("metrics tool should send bound address").port(),
-        result = &mut metrics_handle => {
-            result.unwrap();  // propagates the task's panic (with its message)
-            unreachable!("metrics task exited before sending bound address");
-        }
-    };
+    let metrics_port = addr_rx
+        .await
+        .expect("metrics tool should send bound address")
+        .port();
 
-    for event in events {
-        debug!("publishing: {:?}", event);
+    let payloads: Vec<Vec<u8>> = events.iter().map(|event| event.encode_to_vec()).collect();
+    for (i, payload) in payloads.iter().enumerate() {
+        debug!("publishing payload {}", i + 1);
         nats_publisher
-            .publish(subject.to_string(), event.encode_to_vec())
+            .publish(nats_subject.clone(), payload.clone())
             .await;
     }
 
@@ -182,12 +252,14 @@ async fn publish_and_check(events: &[Event], subject: Subject, expected: &str) {
     loop {
         attempts += 1;
 
-        if metrics_handle.is_finished() {
-            // Surface the real task failure instead of timing out on stale metrics.
-            metrics_handle
-                .await
-                .expect("metrics task should not panic before convergence");
-            panic!("metrics task exited before metrics convergence");
+        match metrics_done_rx.try_recv() {
+            Ok(result) => {
+                panic!("metrics task exited before metrics convergence: {result:?}");
+            }
+            Err(mpsc::TryRecvError::Disconnected) => {
+                panic!("metrics task thread terminated unexpectedly before convergence");
+            }
+            Err(mpsc::TryRecvError::Empty) => {}
         }
 
         match check_metrics(metrics_port, &expected_lines).await {
@@ -216,7 +288,12 @@ async fn publish_and_check(events: &[Event], subject: Subject, expected: &str) {
     }
 
     shutdown_tx.send(true).unwrap();
-    metrics_handle.await.unwrap();
+    match metrics_done_rx.recv_timeout(Duration::from_secs(5)) {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => panic!("metrics task failed during shutdown: {e}"),
+        Err(e) => panic!("metrics task did not report shutdown result: {e}"),
+    }
+    metrics_thread.join().expect("metrics thread should join cleanly");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -224,7 +301,7 @@ async fn test_integration_metrics_no_nats_connection() {
     println!("test that we fail if we can't connect to NATS (due to port 0)");
     setup();
 
-    let args = make_test_args(0, 0);
+    let args = make_test_args(0, 0, "*".to_string());
     let (_, shutdown_rx) = watch::channel(false);
     let result = metrics::run(args, shutdown_rx, None).await;
 

--- a/tools/metrics/tests/integration.rs
+++ b/tools/metrics/tests/integration.rs
@@ -39,7 +39,7 @@ use shared::{
         self,
         io::{AsyncReadExt, AsyncWriteExt},
         net::TcpStream as TokioTcpStream,
-        sync::{oneshot, watch, OnceCell},
+        sync::{oneshot, watch},
         time::sleep,
     },
     util::current_timestamp,
@@ -53,7 +53,7 @@ use std::{
     sync::mpsc,
     sync::{
         atomic::{AtomicU64, Ordering},
-        LazyLock, Once,
+        Arc, LazyLock, Mutex, Once, OnceLock, Weak,
     },
     thread,
     time::Duration,
@@ -61,10 +61,24 @@ use std::{
 };
 
 static INIT: Once = Once::new();
-static SHARED_NATS_PORT: OnceCell<u16> = OnceCell::const_new();
 static TEST_SUBJECT_SEQ: AtomicU64 = AtomicU64::new(1);
 static TEST_SEMAPHORE: LazyLock<shared::tokio::sync::Semaphore> =
     LazyLock::new(|| shared::tokio::sync::Semaphore::new(2));
+static SHARED_NATS: OnceLock<Mutex<Weak<SharedNatsServer>>> = OnceLock::new();
+
+struct SharedNatsServer {
+    port: u16,
+    child: Mutex<Option<std::process::Child>>,
+}
+
+impl Drop for SharedNatsServer {
+    fn drop(&mut self) {
+        if let Some(mut child) = self.child.lock().expect("shared nats child mutex").take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}
 
 fn setup() {
     INIT.call_once(|| {
@@ -89,13 +103,23 @@ fn make_test_args(nats_port: u16, metrics_port: u16, nats_subject: String) -> Ar
     )
 }
 
-async fn shared_nats_port() -> u16 {
-    *SHARED_NATS_PORT
-        .get_or_init(|| async { spawn_shared_nats_server() })
-        .await
+fn shared_nats_server() -> Arc<SharedNatsServer> {
+    let weak_slot = SHARED_NATS.get_or_init(|| Mutex::new(Weak::new()));
+    let mut weak_guard = weak_slot.lock().expect("shared nats weak mutex");
+    if let Some(existing) = weak_guard.upgrade() {
+        return existing;
+    }
+
+    let (port, child) = spawn_shared_nats_server();
+    let server = Arc::new(SharedNatsServer {
+        port,
+        child: Mutex::new(Some(child)),
+    });
+    *weak_guard = Arc::downgrade(&server);
+    server
 }
 
-fn spawn_shared_nats_server() -> u16 {
+fn spawn_shared_nats_server() -> (u16, std::process::Child) {
     let nats_server_binary_path: String = match env::var("NATS_SERVER_BINARY") {
         Ok(b) => b,
         Err(e) => panic!(
@@ -127,8 +151,7 @@ fn spawn_shared_nats_server() -> u16 {
         let deadline = Instant::now() + Duration::from_secs(5);
         while Instant::now() < deadline {
             if TcpStream::connect(&addr).is_ok() {
-                Box::leak(Box::new(child));
-                return port;
+                return (port, child);
             }
             if child.try_wait().expect("try_wait should succeed").is_some() {
                 break;
@@ -195,7 +218,8 @@ async fn publish_and_check(events: &[Event], subject: Subject, expected: &str) {
     setup();
     let _permit = TEST_SEMAPHORE.acquire().await.expect("semaphore closed");
 
-    let nats_port = shared_nats_port().await;
+    let _shared_nats = shared_nats_server();
+    let nats_port = _shared_nats.port;
     let nats_publisher = NatsPublisherForTesting::new(nats_port).await;
     let subject_id = TEST_SUBJECT_SEQ.fetch_add(1, Ordering::Relaxed);
     let nats_subject = format!("{}.{}", subject, subject_id);

--- a/tools/metrics/tests/integration.rs
+++ b/tools/metrics/tests/integration.rs
@@ -210,9 +210,7 @@ async fn publish_and_check(events: &[Event], subject: Subject, expected: &str) {
                 sleep(Duration::from_millis(50)).await;
             }
             Err(e) => {
-                panic!(
-                    "Could not fetch metrics after {attempts} attempts: {e}",
-                );
+                panic!("Could not fetch metrics after {attempts} attempts: {e}",);
             }
         }
     }

--- a/tools/metrics/tests/integration.rs
+++ b/tools/metrics/tests/integration.rs
@@ -39,7 +39,7 @@ use shared::{
         self,
         io::{AsyncReadExt, AsyncWriteExt},
         net::TcpStream as TokioTcpStream,
-        sync::{oneshot, watch},
+        sync::{oneshot, watch, Semaphore},
         time::sleep,
     },
     util::current_timestamp,
@@ -53,7 +53,7 @@ use std::{
     sync::mpsc,
     sync::{
         atomic::{AtomicU64, Ordering},
-        Arc, LazyLock, Mutex, Once, OnceLock, Weak,
+        Arc, Mutex, Once, OnceLock, Weak,
     },
     thread,
     time::Duration,
@@ -62,9 +62,8 @@ use std::{
 
 static INIT: Once = Once::new();
 static TEST_SUBJECT_SEQ: AtomicU64 = AtomicU64::new(1);
-static TEST_SEMAPHORE: LazyLock<shared::tokio::sync::Semaphore> =
-    LazyLock::new(|| shared::tokio::sync::Semaphore::new(2));
 static SHARED_NATS: OnceLock<Mutex<Weak<SharedNatsServer>>> = OnceLock::new();
+static TEST_SEMAPHORE: OnceLock<Semaphore> = OnceLock::new();
 
 struct SharedNatsServer {
     port: u16,
@@ -216,7 +215,11 @@ async fn check_metrics(port: u16, expected: &[&str]) -> Result<bool, std::io::Er
 
 async fn publish_and_check(events: &[Event], subject: Subject, expected: &str) {
     setup();
-    let _permit = TEST_SEMAPHORE.acquire().await.expect("semaphore closed");
+    let _permit = TEST_SEMAPHORE
+        .get_or_init(|| Semaphore::new(2))
+        .acquire()
+        .await
+        .expect("test semaphore should acquire");
 
     let _shared_nats = shared_nats_server();
     let nats_port = _shared_nats.port;
@@ -230,8 +233,7 @@ async fn publish_and_check(events: &[Event], subject: Subject, expected: &str) {
 
     let nats_subject_for_metrics = nats_subject.clone();
     let metrics_thread = thread::spawn(move || {
-        let rt = tokio::runtime::Builder::new_multi_thread()
-            .worker_threads(2)
+        let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
             .expect("metrics runtime should build");


### PR DESCRIPTION
Use port 0 (OS-assigned) for the metrics server in integration tests instead of manually picking random ephemeral ports. This eliminates the race condition that caused intermittent "Address already in use" failures (same pattern as the P2P extractor fix in #358).

The metricserver::start() function now returns the actual bound SocketAddr. The metrics::run() function accepts an optional oneshot::Sender that reports the bound address back to the caller. This also replaces the previous retry loop and 1-second sleep with a proper synchronization barrier via tokio::select!, making tests both faster and more reliable.