### PR TITLE
fix(websocket): use OS-assigned port to fix intermittent test failures

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.c linguist-documentation
+*.h linguist-documentation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,34 @@ jobs:
     - name: Run tests
       run: nix-shell --pure --command "cargo test --all-features"
 
+  nix-test-detect-intermittent-failures:
+    runs-on: ubuntu-latest
+    needs: nix-test
+    steps:
+    - uses: actions/checkout@v6
+    - uses: ./.github/actions/setup-nix-action
+    # use separate steps for iterations here to easily see on GHA the time it took
+    - name: Iteration 0
+      run: nix-shell --pure --command "cargo test --all-features"
+    - name: Iteration 1
+      run: nix-shell --pure --command "cargo test --all-features"
+    - name: Iteration 2
+      run: nix-shell --pure --command "cargo test --all-features"
+    - name: Iteration 3
+      run: nix-shell --pure --command "cargo test --all-features"
+    - name: Iteration 4
+      run: nix-shell --pure --command "cargo test --all-features"
+    - name: Iteration 5
+      run: nix-shell --pure --command "cargo test --all-features"
+    - name: Iteration 6
+      run: nix-shell --pure --command "cargo test --all-features"
+    - name: Iteration 7
+      run: nix-shell --pure --command "cargo test --all-features"
+    - name: Iteration 8
+      run: nix-shell --pure --command "cargo test --all-features"
+    - name: Iteration 9
+      run: nix-shell --pure --command "cargo test --all-features"
+
   nix-format:
     runs-on: ubuntu-latest
     steps:
@@ -81,6 +109,36 @@ jobs:
     - name: Install integration test dependecies
       run: sudo apt-get install -y nats-server
     - name: Run tests and integration tests
+      run: NATS_SERVER_BINARY=$(which nats-server) cargo test --all-features
+
+  ubuntu-test-detect-intermittent-failures:
+    runs-on: ubuntu-latest
+    needs: ubuntu-test
+    steps:
+    - uses: actions/checkout@v6
+    - uses: ./.github/actions/setup-ubuntu-action
+    - name: Install integration test dependecies
+      run: sudo apt-get install -y nats-server
+    # use separate steps for iterations here to easily see on GHA the time it took
+    - name: Iteration 0
+      run: NATS_SERVER_BINARY=$(which nats-server) cargo test --all-features
+    - name: Iteration 1
+      run: NATS_SERVER_BINARY=$(which nats-server) cargo test --all-features
+    - name: Iteration 2
+      run: NATS_SERVER_BINARY=$(which nats-server) cargo test --all-features
+    - name: Iteration 3
+      run: NATS_SERVER_BINARY=$(which nats-server) cargo test --all-features
+    - name: Iteration 4
+      run: NATS_SERVER_BINARY=$(which nats-server) cargo test --all-features
+    - name: Iteration 5
+      run: NATS_SERVER_BINARY=$(which nats-server) cargo test --all-features
+    - name: Iteration 6
+      run: NATS_SERVER_BINARY=$(which nats-server) cargo test --all-features
+    - name: Iteration 7
+      run: NATS_SERVER_BINARY=$(which nats-server) cargo test --all-features
+    - name: Iteration 8
+      run: NATS_SERVER_BINARY=$(which nats-server) cargo test --all-features
+    - name: Iteration 9
       run: NATS_SERVER_BINARY=$(which nats-server) cargo test --all-features
 
   ubuntu-docs-tools:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,9 +263,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 dependencies = [
  "serde",
 ]
@@ -1289,9 +1289,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "openssl-probe"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -624,7 +624,7 @@ name = "ebpf-extractor"
 version = "0.1.0"
 dependencies = [
  "libbpf-cargo",
- "libbpf-rs",
+ "libbpf-rs 0.25.0",
  "shared",
 ]
 
@@ -1088,14 +1088,14 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libbpf-cargo"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "626c6fbcb5088716de86d0ccbdccedc17b13e59f41a605a3274029335e71fcbb"
+checksum = "fdd59674b82a31cb53e512cee97e3d5143737b40feda35f89b5b7f5c439e51e8"
 dependencies = [
  "anyhow",
  "cargo_metadata",
  "clap",
- "libbpf-rs",
+ "libbpf-rs 0.26.1",
  "libbpf-sys",
  "memmap2",
  "serde",
@@ -1118,10 +1118,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "libbpf-sys"
-version = "1.5.0+v1.5.0"
+name = "libbpf-rs"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d8306b516a70a129cb6afed17c1e51e162d35aadfcc6339364addcebe32de90"
+checksum = "a6af29f679fd713ba4466b0296436268f573f6c5a8ef2f316d237eb3019c3c6f"
+dependencies = [
+ "bitflags 2.4.0",
+ "libbpf-sys",
+ "libc",
+ "vsprintf",
+]
+
+[[package]]
+name = "libbpf-sys"
+version = "1.6.3+v1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95f55336f7dbde4fbbaae7b5e271f9efc65bf1d0b69c6fcb1e5026a385e95f70"
 dependencies = [
  "cc",
  "nix",
@@ -1130,9 +1142,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "libredox"
@@ -1201,9 +1213,9 @@ checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
 
 [[package]]
 name = "memmap2"
-version = "0.5.10"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
 ]
@@ -1244,9 +1256,9 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "nix"
-version = "0.29.0"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
 dependencies = [
  "bitflags 2.4.0",
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -624,7 +624,7 @@ name = "ebpf-extractor"
 version = "0.1.0"
 dependencies = [
  "libbpf-cargo",
- "libbpf-rs 0.25.0",
+ "libbpf-rs",
  "shared",
 ]
 
@@ -1095,7 +1095,7 @@ dependencies = [
  "anyhow",
  "cargo_metadata",
  "clap",
- "libbpf-rs 0.26.1",
+ "libbpf-rs",
  "libbpf-sys",
  "memmap2",
  "serde",
@@ -1103,18 +1103,6 @@ dependencies = [
  "tempfile",
  "tracing",
  "tracing-subscriber",
-]
-
-[[package]]
-name = "libbpf-rs"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e23d252d93e246c8787198369f06806c99c5077b5295be29505295f4e5426dc4"
-dependencies = [
- "bitflags 2.4.0",
- "libbpf-sys",
- "libc",
- "vsprintf",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2149,9 +2149,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",

--- a/README.md
+++ b/README.md
@@ -24,31 +24,31 @@ selected P2P measurements as events into a NATS pub-sub queue.
 
 The `log-extractor` publishes them parsed `debug.log` log messages as events to NATS.
 
-The tools are written in Python or Rust (or any other language that supports NATS
-and protobuf). They subscribe to the NATS server. For example, the `logger` tool
-simply prints out all messages that it receives, the `metrics` tool produces prometheus
-metrics, and the `addr-connectivity` tool tests received addresses if they are reachable.
-Python tools can make use of the `protobuf/python-types` to deserialize the Protobuf
-messages while Rust tools can use the types from the `shared` Rust module.
+The tools are written in Rust (or any other language that supports NATS 
+and protobuf). They subscribe to the NATS server. For example, the `logger` tool 
+simply prints out all messages that it receives, the `metrics` tool produces prometheus 
+metrics, and the `connectivity-check` tool tests received addresses if they are reachable. 
+Rust tools can use the types from the `shared` Rust module to deserialize the Protobuf 
+messages. For other languages, types can be generated directly from the Protobuf definitions.
 
 ```
                                            protobuf
                                            messages
-┌─────────────┐    ┌───────────────┐     ┌─────────┐      ┌────────────────────┐
-│             ├────► ebpf-extractor├─────┤         │      │                    │
-│             │    └───────────────┘     │         │      │ Tools              │
-│             │                          │         │      │                    │
-│             │    ┌───────────────┐     │         ├──────┼──►logger           │
-│             ├────► rpc-extractor │─────┤         │      │                    │
-│   Bitcoin   │    └───────────────┘     │ NATS.io ├──────┼──►metrics          │
-│             │                          │         │      │                    │
-│     Node    │    ┌───────────────┐     │ PUB-SUB ├──────┼──►websocket        │
-│             ├────► p2p-extractor │─────┤         │      │                    │
-│             │    └───────────────┘     │         ├──────┼──►addr-connectivty │
-│             │                          │         │      │                    │
-│             │    ┌───────────────┐     │         │      │   ...              │
-│             ├────► log-extractor │─────┤         │      │                    │
-└─────────────┘    └───────────────┘     └─────────┘      └────────────────────┘
+┌─────────────┐    ┌───────────────┐     ┌─────────┐      ┌──────────────────────┐
+│             ├────► ebpf-extractor├─────┤         │      │                      │
+│             │    └───────────────┘     │         │      │ Tools                │
+│             │                          │         │      │                      │
+│             │    ┌───────────────┐     │         ├──────┼──►logger             │
+│             ├────► rpc-extractor │─────┤         │      │                      │
+│   Bitcoin   │    └───────────────┘     │ NATS.io ├──────┼──►metrics            │
+│             │                          │         │      │                      │
+│     Node    │    ┌───────────────┐     │ PUB-SUB ├──────┼──►websocket          │
+│             ├────► p2p-extractor │─────┤         │      │                      │
+│             │    └───────────────┘     │         ├──────┼──►connectivity-check │
+│             │                          │         │      │                      │
+│             │    ┌───────────────┐     │         │      │   ...                │
+│             ├────► log-extractor │─────┤         │      │                      │
+└─────────────┘    └───────────────┘     └─────────┘      └──────────────────────┘
 
  (edit on asciiflow.com)
 ```
@@ -81,7 +81,6 @@ tool uses the events differently:
 | metrics               | produces prometheus metrics from events.                                         | `rust`       | [tools/metrics/](tools/metrics)         |
 | websocket             | publishes events into a websocket as JSON                                        | `rust`       | [tools/websocket/](tools/websocket)     |
 | connectivity-check    | connects to IP addresses received via `addr(v2)` messages and records the result | `rust`       | [tools/connectivity-check/](tools/connectivity-check)    |
-| record-getblocktxn-py | records sent and received `getblocktxn` messages                                 | `python`     | [tools/record-getblocktxn-py/](tools/record-getblocktxn-py) |
 
 ## Real-world usage
 

--- a/extractors/ebpf/Cargo.toml
+++ b/extractors/ebpf/Cargo.toml
@@ -11,7 +11,7 @@ shared = { path = "../../shared" }
 libbpf-rs = "0.25"
 
 [build-dependencies]
-libbpf-cargo = "0.25"
+libbpf-cargo = "0.26"
 
 [features]
 # Treat warnings as a build error.

--- a/extractors/ebpf/Cargo.toml
+++ b/extractors/ebpf/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 shared = { path = "../../shared" }
 
-libbpf-rs = "0.25"
+libbpf-rs = "0.26"
 
 [build-dependencies]
 libbpf-cargo = "0.26"

--- a/extractors/log/tests/integration.rs
+++ b/extractors/log/tests/integration.rs
@@ -22,6 +22,7 @@ use shared::{
         time::{Duration, sleep},
     },
 };
+use std::io::Write;
 use std::str::FromStr;
 use std::sync::Once;
 
@@ -37,6 +38,57 @@ fn setup() {
             .init()
             .unwrap();
     });
+}
+
+/// Appends a marker line to `debug.log` with a valid RFC 3339 timestamp so the
+/// log parser treats it as an `UnknownLogMessage`.
+fn write_marker(log_path: &str, marker: &str) {
+    let mut file = std::fs::OpenOptions::new()
+        .append(true)
+        .open(log_path)
+        .expect("failed to open debug.log for appending");
+    writeln!(file, "2026-01-01T00:00:00Z {marker}").expect("failed to write marker");
+}
+
+/// Waits until `marker` arrives via NATS as an `UnknownLogMessage`, proving the
+/// full debug.log -> tail -> pipe -> extractor -> NATS pipeline is live.
+/// Returns any `PeerObserverEvent`s consumed before the marker so callers can
+/// replay them through their assertion logic (prevents event starvation).
+/// Panics on timeout.
+async fn wait_for_marker(
+    sub: &mut shared::async_nats::Subscriber,
+    marker: &str,
+    timeout: Duration,
+) -> Vec<PeerObserverEvent> {
+    let mut buffered = Vec::new();
+    let mut marker_seen = false;
+    select! {
+        _ = sleep(timeout) => {
+            panic!("timed out waiting for pipeline-ready marker '{marker}'");
+        }
+        _ = async {
+            while let Some(msg) = sub.next().await {
+                if let Ok(event) = Event::decode(msg.payload) {
+                    if let Some(PeerObserverEvent::LogExtractor(ref r)) = event.peer_observer_event
+                        && let Some(log::LogEvent::UnknownLogMessage(ref u)) = r.log_event
+                        && u.raw_message.contains(marker)
+                    {
+                        info!("received pipeline-ready marker: {marker}");
+                        marker_seen = true;
+                        return;
+                    }
+                    if let Some(pe) = event.peer_observer_event {
+                        buffered.push(pe);
+                    }
+                }
+            }
+        } => {}
+    }
+    assert!(
+        marker_seen,
+        "NATS subscription stream closed before pipeline-ready marker '{marker}' arrived"
+    );
+    buffered
 }
 
 /// Bridges Bitcoin Core's `debug.log` into a named pipe for the log extractor.
@@ -122,18 +174,23 @@ fn setup_two_connected_nodes(node1_args: Vec<&str>) -> (corepc_node::Node, corep
 /// 1. Initializes logging and spins up two connected regtest nodes (node1
 ///    accepts inbound P2P; node2 connects to it). `args` are passed as extra
 ///    bitcoind CLI flags to node1 (e.g. `-debug=validation`).
-/// 2. Starts a throwaway NATS server and launches the log extractor, which
-///    reads node1's `debug.log` via a named pipe (`mkfifo` + `tail -f`) and
-///    publishes protobuf-encoded events to NATS.
-/// 3. Calls `test_setup` against node1's RPC client so the test can trigger
+/// 2. Starts a throwaway NATS server and subscribes *before* launching the
+///    extractor, so startup events are not lost.
+/// 3. Launches the log extractor, which reads node1's `debug.log` via a named
+///    pipe (`mkfifo` + `tail -f`) and publishes protobuf-encoded events to
+///    NATS.
+/// 4. Performs an end-to-end pipeline handshake: writes a unique marker line
+///    into `debug.log` and waits for it to arrive via NATS, buffering any
+///    events consumed before the marker. This proves the full
+///    `debug.log -> tail -> pipe -> extractor -> NATS` path is live.
+/// 5. Calls `test_setup` against node1's RPC client so the test can trigger
 ///    the specific node behaviour it wants to observe (mine a block, submit a
 ///    transaction, etc.).
-/// 4. Subscribes to all NATS subjects and polls incoming messages, decoding
-///    each into a `PeerObserverEvent` and passing it to `check_event`. The
-///    loop breaks as soon as `check_event` returns `true`, signalling that the
-///    expected event was received.
-/// 5. Panics if the expected event is not seen within `TEST_TIMEOUT_SECONDS`.
-/// 6. Sends a shutdown signal to the log extractor task and awaits its clean
+/// 6. Replays buffered pre-marker events through `check_event`, then polls
+///    live NATS messages. The loop breaks as soon as `check_event` returns
+///    `true`.
+/// 7. Panics if the expected event is not seen within `TEST_TIMEOUT_SECONDS`.
+/// 8. Sends a shutdown signal to the log extractor task and awaits its clean
 ///    exit before returning.
 async fn check(
     args: Vec<&str>,
@@ -143,25 +200,43 @@ async fn check(
     setup();
     let (node1, _node2) = setup_two_connected_nodes(args);
     let nats_server = NatsServerForTesting::new(&[]).await;
+    let nats_port = nats_server.port;
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
 
+    // Subscribe BEFORE spawning the extractor so that startup events
+    // published between extractor start and subscription are not lost.
+    // Without this, tests with no-op test_setup() starve because the
+    // only events they could ever match were already published.
+    let nc = async_nats::connect(format!("127.0.0.1:{}", nats_port))
+        .await
+        .unwrap();
+    let mut sub = nc.subscribe("*").await.unwrap();
+
     let node1_workdir = node1.workdir().to_str().unwrap().to_string();
+    let log_path = format!("{}/regtest/debug.log", node1_workdir);
+    let log_path_main = log_path.clone();
     let log_extractor_handle = tokio::spawn(async move {
-        let log_path = format!("{}/regtest/debug.log", node1_workdir);
         let pipe_path = format!("{}/bitcoind_pipe", node1_workdir);
         spawn_pipe(log_path, pipe_path.clone());
 
-        let args = make_test_args(nats_server.port, pipe_path.to_string());
+        let args = make_test_args(nats_port, pipe_path.to_string());
 
         log_extractor::run(args, shutdown_rx.clone())
             .await
             .expect("log extractor failed");
     });
 
-    let nc = async_nats::connect(format!("127.0.0.1:{}", nats_server.port))
-        .await
-        .unwrap();
-    let mut sub = nc.subscribe("*").await.unwrap();
+    // End-to-end pipeline handshake: write a unique marker into debug.log
+    // and wait for it to arrive via NATS, proving the full
+    // debug.log -> tail -> pipe -> extractor -> NATS path is live.
+    // Events consumed before the marker are buffered for replay.
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let marker = format!("PIPELINE_READY:{nanos}");
+    write_marker(&log_path_main, &marker);
+    let buffered = wait_for_marker(&mut sub, &marker, Duration::from_secs(10)).await;
 
     test_setup(&node1.client);
 
@@ -171,7 +246,15 @@ async fn check(
         _ = sleep(Duration::from_secs(TEST_TIMEOUT_SECONDS)) => {
             panic!("timed out waiting for check() to complete");
         }
-        _ = async { while let Some(msg) = sub.next().await {
+        _ = async {
+            // Replay events consumed during the marker handshake so tests
+            // that rely on early/startup events are not starved.
+            for event in buffered {
+                if check_event(event) {
+                    return;
+                }
+            }
+            while let Some(msg) = sub.next().await {
                 let unwrapped = Event::decode(msg.payload).unwrap();
                 if let Some(event) = unwrapped.peer_observer_event
                     && check_event(event)

--- a/extractors/log/tests/integration.rs
+++ b/extractors/log/tests/integration.rs
@@ -349,9 +349,10 @@ async fn test_integration_logextractor_block_checked() {
         |event| {
             match event {
                 PeerObserverEvent::LogExtractor(r) => {
-                    if let Some(log::LogEvent::BlockCheckedLog(block_checked)) = r.log_event {
+                    if let Some(log::LogEvent::BlockCheckedLog(block_checked)) = r.log_event
+                        && block_checked.state == "Valid"
+                    {
                         assert!(!block_checked.block_hash.is_empty());
-                        assert_eq!(block_checked.state, "Valid");
                         info!("BlockCheckedLog event {}", block_checked);
                         return true;
                     }
@@ -400,8 +401,8 @@ async fn test_integration_logextractor_mutated_block_bad_witness_nonce_size() {
                 PeerObserverEvent::LogExtractor(r) => {
                     if let Some(ref e) = r.log_event
                         && let log::LogEvent::BlockCheckedLog(block_checked) = e
+                        && block_checked.state == "bad-witness-nonce-size"
                     {
-                        assert_eq!(block_checked.state, "bad-witness-nonce-size");
                         assert_eq!(
                             block_checked.debug_message,
                             "CheckWitnessMalleation : invalid witness reserved value size"
@@ -455,8 +456,8 @@ async fn test_integration_logextractor_mutated_block_bad_txnmrklroot() {
                 PeerObserverEvent::LogExtractor(l) => {
                     if let Some(ref e) = l.log_event
                         && let log::LogEvent::BlockCheckedLog(block_checked) = e
+                        && block_checked.state == "bad-txnmrklroot"
                     {
-                        assert_eq!(block_checked.state, "bad-txnmrklroot");
                         assert_eq!(block_checked.debug_message, "hashMerkleRoot mismatch");
                         info!("BlockCheckedLog event {}", block_checked);
                         return true;

--- a/extractors/rpc/README.md
+++ b/extractors/rpc/README.md
@@ -45,6 +45,8 @@ Options:
           Interval (in seconds) in which to query from the Bitcoin Core RPC endpoint [default: 10]
       --query-interval-less-frequent <QUERY_INTERVAL_LESS_FREQUENT>
           Interval (in seconds) in which to query resource-intensive or less frequently changing RPCs from the Bitcoin Core RPC endpoint. These currently include: - getchaintxstats (infrequent changes) - getblockchaininfo (infrequent changes) - getrawaddrman (resource intensive) [default: 120]
+      --prometheus-address <PROMETHEUS_ADDRESS>
+          Address to serve Prometheus metrics on [default: 127.0.0.1:8284]
       --disable-getpeerinfo
           Disable querying and publishing of `getpeerinfo` data
       --disable-getmempoolinfo

--- a/extractors/rpc/src/lib.rs
+++ b/extractors/rpc/src/lib.rs
@@ -15,8 +15,10 @@ use shared::tokio::time::{self, Duration};
 use shared::{async_nats, clap};
 
 mod error;
+pub mod metrics;
 
 use error::{FetchOrPublishError, RuntimeError};
+use metrics::Metrics;
 
 /// The peer-observer rpc-extractor periodically queries data from the
 /// Bitcoin Core RPC endpoint and publishes the results as events into
@@ -66,6 +68,10 @@ pub struct Args {
     /// - getrawaddrman (resource intensive)
     #[arg(long, default_value_t = 120)]
     pub query_interval_less_frequent: u64,
+
+    /// Address to serve Prometheus metrics on.
+    #[arg(long, default_value = "127.0.0.1:8284")]
+    pub prometheus_address: String,
 
     /// Disable querying and publishing of `getpeerinfo` data.
     #[arg(long, default_value_t = false)]
@@ -121,6 +127,7 @@ impl Args {
         rpc_cookie_file: String,
         query_interval: u64,
         query_interval_less_frequent: u64,
+        prometheus_address: String,
         disable_getpeerinfo: bool,
         disable_getmempoolinfo: bool,
         disable_uptime: bool,
@@ -142,6 +149,7 @@ impl Args {
             rpc_cookie_file: Some(rpc_cookie_file),
             query_interval,
             query_interval_less_frequent,
+            prometheus_address,
             disable_getpeerinfo,
             disable_getmempoolinfo,
             disable_uptime,
@@ -159,6 +167,12 @@ impl Args {
 }
 
 pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(), RuntimeError> {
+    // Create metrics instance with its own registry
+    let metrics = Metrics::new();
+
+    // Start the metric server with our custom registry.
+    shared::metricserver::start(&args.prometheus_address, Some(metrics.registry.clone()))?;
+
     let auth: Auth = match args.rpc_cookie_file {
         Some(path) => Auth::CookieFile(path.into()),
         None => Auth::UserPass(
@@ -249,50 +263,50 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
         shared::tokio::select! {
             _ = interval.tick() => {
                 if !args.disable_getpeerinfo
-                    && let Err(e) = getpeerinfo(&rpc_client, &nats_client).await {
+                    && let Err(e) = getpeerinfo(&rpc_client, &nats_client, &metrics).await {
                         log::error!("Could not fetch and publish 'getpeerinfo': {}", e)
                     }
                 if !args.disable_getmempoolinfo
-                    && let Err(e) = getmempoolinfo(&rpc_client, &nats_client).await {
+                    && let Err(e) = getmempoolinfo(&rpc_client, &nats_client, &metrics).await {
                         log::error!("Could not fetch and publish 'getmempoolinfo': {}", e)
                     }
                 if !args.disable_uptime
-                    && let Err(e) = uptime(&rpc_client, &nats_client).await {
+                    && let Err(e) = uptime(&rpc_client, &nats_client, &metrics).await {
                         log::error!("Could not fetch and publish 'uptime': {}", e)
                     }
                 if !args.disable_getnettotals
-                    && let Err(e) = getnettotals(&rpc_client, &nats_client).await {
+                    && let Err(e) = getnettotals(&rpc_client, &nats_client, &metrics).await {
                         log::error!("Could not fetch and publish 'getnettotals': {}", e)
                     }
                 if !args.disable_getmemoryinfo
-                    && let Err(e) = getmemoryinfo(&rpc_client, &nats_client).await {
+                    && let Err(e) = getmemoryinfo(&rpc_client, &nats_client, &metrics).await {
                         log::error!("Could not fetch and publish 'getmemoryinfo': {}", e)
                     }
                 if !args.disable_getaddrmaninfo
-                    && let Err(e) = getaddrmaninfo(&rpc_client, &nats_client).await {
+                    && let Err(e) = getaddrmaninfo(&rpc_client, &nats_client, &metrics).await {
                         log::error!("Could not fetch and publish 'getaddrmaninfo': {}", e)
                     }
                 if !args.disable_getnetworkinfo
-                    && let Err(e) = getnetworkinfo(&rpc_client, &nats_client).await {
+                    && let Err(e) = getnetworkinfo(&rpc_client, &nats_client, &metrics).await {
                         log::error!("Could not fetch and publish 'getnetworkinfo': {}", e)
                 }
                 if !args.disable_getorphantxs
-                    && let Err(e) = getorphantxs(&rpc_client, &nats_client).await {
+                    && let Err(e) = getorphantxs(&rpc_client, &nats_client, &metrics).await {
                         log::error!("Could not fetch and publish 'getorphantxs': {}", e)
                 }
             }
             _ = less_frequent_interval.tick() => {
                 // make sure to update the Args docs when changing these:
                 if !args.disable_getchaintxstats
-                    && let Err(e) = getchaintxstats(&rpc_client, &nats_client).await {
+                    && let Err(e) = getchaintxstats(&rpc_client, &nats_client, &metrics).await {
                         log::error!("Could not fetch and publish 'getchaintxstats': {}", e)
                 }
                 if !args.disable_getblockchaininfo
-                    && let Err(e) = getblockchaininfo(&rpc_client, &nats_client).await {
+                    && let Err(e) = getblockchaininfo(&rpc_client, &nats_client, &metrics).await {
                         log::error!("Could not fetch and publish 'getblockchaininfo': {}", e)
                 }
                 if !args.disable_getrawaddrman
-                    && let Err(e) = getrawaddrman(&rpc_client, &nats_client).await {
+                    && let Err(e) = getrawaddrman(&rpc_client, &nats_client, &metrics).await {
                         log::error!("Could not fetch and publish 'getrawaddrman': {}", e)
                 }
             }
@@ -316,11 +330,36 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
     Ok(())
 }
 
+fn measure_rpc_call<T, E, F>(method_name: &str, metrics: &Metrics, f: F) -> Result<T, E>
+where
+    F: FnOnce() -> Result<T, E>,
+{
+    let timer = metrics
+        .rpc_fetch_duration
+        .with_label_values(&[method_name])
+        .start_timer();
+    let res = f();
+    match &res {
+        Ok(_) => {
+            timer.stop_and_record();
+        }
+        Err(_) => {
+            timer.stop_and_discard();
+            metrics
+                .rpc_fetch_errors
+                .with_label_values(&[method_name])
+                .inc();
+        }
+    }
+    res
+}
+
 async fn getpeerinfo(
     rpc_client: &Client,
     nats_client: &async_nats::Client,
+    metrics: &Metrics,
 ) -> Result<(), FetchOrPublishError> {
-    let peer_info = rpc_client.get_peer_info()?;
+    let peer_info = measure_rpc_call("getpeerinfo", metrics, || rpc_client.get_peer_info())?;
 
     let proto = Event::new(PeerObserverEvent::RpcExtractor(rpc_extractor::Rpc {
         rpc_event: Some(rpc_extractor::rpc::RpcEvent::PeerInfos(peer_info.into())),
@@ -328,15 +367,24 @@ async fn getpeerinfo(
 
     nats_client
         .publish(Subject::Rpc.to_string(), proto.encode_to_vec().into())
-        .await?;
+        .await
+        .inspect_err(|_| {
+            metrics
+                .nats_publish_errors
+                .with_label_values(&["getpeerinfo"])
+                .inc();
+        })?;
     Ok(())
 }
 
 async fn getmempoolinfo(
     rpc_client: &Client,
     nats_client: &async_nats::Client,
+    metrics: &Metrics,
 ) -> Result<(), FetchOrPublishError> {
-    let mempool_info = rpc_client.get_mempool_info()?.into_model()?;
+    let mempool_info =
+        measure_rpc_call("getmempoolinfo", metrics, || rpc_client.get_mempool_info())?
+            .into_model()?;
 
     let proto = Event::new(PeerObserverEvent::RpcExtractor(rpc_extractor::Rpc {
         rpc_event: Some(rpc_extractor::rpc::RpcEvent::MempoolInfo(
@@ -346,15 +394,22 @@ async fn getmempoolinfo(
 
     nats_client
         .publish(Subject::Rpc.to_string(), proto.encode_to_vec().into())
-        .await?;
+        .await
+        .inspect_err(|_| {
+            metrics
+                .nats_publish_errors
+                .with_label_values(&["getmempoolinfo"])
+                .inc();
+        })?;
     Ok(())
 }
 
 async fn uptime(
     rpc_client: &Client,
     nats_client: &async_nats::Client,
+    metrics: &Metrics,
 ) -> Result<(), FetchOrPublishError> {
-    let uptime_seconds = rpc_client.uptime()?;
+    let uptime_seconds = measure_rpc_call("uptime", metrics, || rpc_client.uptime())?;
 
     let proto = Event::new(PeerObserverEvent::RpcExtractor(rpc_extractor::Rpc {
         rpc_event: Some(rpc_extractor::rpc::RpcEvent::Uptime(uptime_seconds)),
@@ -362,15 +417,22 @@ async fn uptime(
 
     nats_client
         .publish(Subject::Rpc.to_string(), proto.encode_to_vec().into())
-        .await?;
+        .await
+        .inspect_err(|_| {
+            metrics
+                .nats_publish_errors
+                .with_label_values(&["uptime"])
+                .inc();
+        })?;
     Ok(())
 }
 
 async fn getnettotals(
     rpc_client: &Client,
     nats_client: &async_nats::Client,
+    metrics: &Metrics,
 ) -> Result<(), FetchOrPublishError> {
-    let net_totals = rpc_client.get_net_totals()?;
+    let net_totals = measure_rpc_call("getnettotals", metrics, || rpc_client.get_net_totals())?;
 
     let proto = Event::new(PeerObserverEvent::RpcExtractor(rpc_extractor::Rpc {
         rpc_event: Some(rpc_extractor::rpc::RpcEvent::NetTotals(net_totals.into())),
@@ -378,15 +440,22 @@ async fn getnettotals(
 
     nats_client
         .publish(Subject::Rpc.to_string(), proto.encode_to_vec().into())
-        .await?;
+        .await
+        .inspect_err(|_| {
+            metrics
+                .nats_publish_errors
+                .with_label_values(&["getnettotals"])
+                .inc();
+        })?;
     Ok(())
 }
 
 async fn getmemoryinfo(
     rpc_client: &Client,
     nats_client: &async_nats::Client,
+    metrics: &Metrics,
 ) -> Result<(), FetchOrPublishError> {
-    let memory_info = rpc_client.get_memory_info()?;
+    let memory_info = measure_rpc_call("getmemoryinfo", metrics, || rpc_client.get_memory_info())?;
 
     let proto = Event::new(PeerObserverEvent::RpcExtractor(rpc_extractor::Rpc {
         rpc_event: Some(rpc_extractor::rpc::RpcEvent::MemoryInfo(memory_info.into())),
@@ -394,15 +463,23 @@ async fn getmemoryinfo(
 
     nats_client
         .publish(Subject::Rpc.to_string(), proto.encode_to_vec().into())
-        .await?;
+        .await
+        .inspect_err(|_| {
+            metrics
+                .nats_publish_errors
+                .with_label_values(&["getmemoryinfo"])
+                .inc();
+        })?;
     Ok(())
 }
 
 async fn getaddrmaninfo(
     rpc_client: &Client,
     nats_client: &async_nats::Client,
+    metrics: &Metrics,
 ) -> Result<(), FetchOrPublishError> {
-    let addrman_info = rpc_client.get_addr_man_info()?;
+    let addrman_info =
+        measure_rpc_call("getaddrmaninfo", metrics, || rpc_client.get_addr_man_info())?;
 
     let proto = Event::new(PeerObserverEvent::RpcExtractor(rpc_extractor::Rpc {
         rpc_event: Some(rpc_extractor::rpc::RpcEvent::AddrmanInfo(
@@ -412,15 +489,25 @@ async fn getaddrmaninfo(
 
     nats_client
         .publish(Subject::Rpc.to_string(), proto.encode_to_vec().into())
-        .await?;
+        .await
+        .inspect_err(|_| {
+            metrics
+                .nats_publish_errors
+                .with_label_values(&["getaddrmaninfo"])
+                .inc();
+        })?;
     Ok(())
 }
 
 async fn getchaintxstats(
     rpc_client: &Client,
     nats_client: &async_nats::Client,
+    metrics: &Metrics,
 ) -> Result<(), FetchOrPublishError> {
-    let chain_tx_stats: GetChainTxStats = rpc_client.get_chain_tx_stats()?.into_model()?;
+    let chain_tx_stats: GetChainTxStats = measure_rpc_call("getchaintxstats", metrics, || {
+        rpc_client.get_chain_tx_stats()
+    })?
+    .into_model()?;
 
     let proto = Event::new(PeerObserverEvent::RpcExtractor(rpc_extractor::Rpc {
         rpc_event: Some(rpc_extractor::rpc::RpcEvent::ChainTxStats(
@@ -430,15 +517,24 @@ async fn getchaintxstats(
 
     nats_client
         .publish(Subject::Rpc.to_string(), proto.encode_to_vec().into())
-        .await?;
+        .await
+        .inspect_err(|_| {
+            metrics
+                .nats_publish_errors
+                .with_label_values(&["getchaintxstats"])
+                .inc();
+        })?;
     Ok(())
 }
 
 async fn getnetworkinfo(
     rpc_client: &Client,
     nats_client: &async_nats::Client,
+    metrics: &Metrics,
 ) -> Result<(), FetchOrPublishError> {
-    let network_info: GetNetworkInfo = rpc_client.get_network_info()?.into_model()?;
+    let network_info: GetNetworkInfo =
+        measure_rpc_call("getnetworkinfo", metrics, || rpc_client.get_network_info())?
+            .into_model()?;
 
     let proto = Event::new(PeerObserverEvent::RpcExtractor(rpc_extractor::Rpc {
         rpc_event: Some(rpc_extractor::rpc::RpcEvent::NetworkInfo(
@@ -448,15 +544,26 @@ async fn getnetworkinfo(
 
     nats_client
         .publish(Subject::Rpc.to_string(), proto.encode_to_vec().into())
-        .await?;
+        .await
+        .inspect_err(|_| {
+            metrics
+                .nats_publish_errors
+                .with_label_values(&["getnetworkinfo"])
+                .inc();
+        })?;
     Ok(())
 }
 
 async fn getblockchaininfo(
     rpc_client: &Client,
     nats_client: &async_nats::Client,
+    metrics: &Metrics,
 ) -> Result<(), FetchOrPublishError> {
-    let blockchain_info: GetBlockchainInfo = rpc_client.get_blockchain_info()?.into_model()?;
+    let blockchain_info: GetBlockchainInfo =
+        measure_rpc_call("getblockchaininfo", metrics, || {
+            rpc_client.get_blockchain_info()
+        })?
+        .into_model()?;
 
     let proto = Event::new(PeerObserverEvent::RpcExtractor(rpc_extractor::Rpc {
         rpc_event: Some(rpc_extractor::rpc::RpcEvent::BlockchainInfo(
@@ -466,15 +573,25 @@ async fn getblockchaininfo(
 
     nats_client
         .publish(Subject::Rpc.to_string(), proto.encode_to_vec().into())
-        .await?;
+        .await
+        .inspect_err(|_| {
+            metrics
+                .nats_publish_errors
+                .with_label_values(&["getblockchaininfo"])
+                .inc();
+        })?;
     Ok(())
 }
 
 async fn getorphantxs(
     rpc_client: &Client,
     nats_client: &async_nats::Client,
+    metrics: &Metrics,
 ) -> Result<(), FetchOrPublishError> {
-    let orphans: GetOrphanTxsVerboseTwo = rpc_client.get_orphan_txs_verbosity_2()?.into_model()?;
+    let orphans: GetOrphanTxsVerboseTwo = measure_rpc_call("getorphantxs", metrics, || {
+        rpc_client.get_orphan_txs_verbosity_2()
+    })?
+    .into_model()?;
 
     let proto = Event::new(PeerObserverEvent::RpcExtractor(rpc_extractor::Rpc {
         rpc_event: Some(rpc_extractor::rpc::RpcEvent::OrphanTxs(orphans.into())),
@@ -482,15 +599,22 @@ async fn getorphantxs(
 
     nats_client
         .publish(Subject::Rpc.to_string(), proto.encode_to_vec().into())
-        .await?;
+        .await
+        .inspect_err(|_| {
+            metrics
+                .nats_publish_errors
+                .with_label_values(&["getorphantxs"])
+                .inc();
+        })?;
     Ok(())
 }
 
 async fn getrawaddrman(
     rpc_client: &Client,
     nats_client: &async_nats::Client,
+    metrics: &Metrics,
 ) -> Result<(), FetchOrPublishError> {
-    let addrman = rpc_client.get_raw_addrman()?;
+    let addrman = measure_rpc_call("getrawaddrman", metrics, || rpc_client.get_raw_addrman())?;
 
     let proto = Event::new(PeerObserverEvent::RpcExtractor(rpc_extractor::Rpc {
         rpc_event: Some(rpc_extractor::rpc::RpcEvent::Addrman(addrman.into())),
@@ -498,6 +622,12 @@ async fn getrawaddrman(
 
     nats_client
         .publish(Subject::Rpc.to_string(), proto.encode_to_vec().into())
-        .await?;
+        .await
+        .inspect_err(|_| {
+            metrics
+                .nats_publish_errors
+                .with_label_values(&["getrawaddrman"])
+                .inc();
+        })?;
     Ok(())
 }

--- a/extractors/rpc/src/metrics.rs
+++ b/extractors/rpc/src/metrics.rs
@@ -1,0 +1,76 @@
+use shared::prometheus::{
+    HistogramOpts, HistogramVec, IntCounterVec, Opts, Registry,
+    register_histogram_vec_with_registry, register_int_counter_vec_with_registry,
+};
+
+const NAMESPACE: &str = "rpcextractor";
+
+pub const LABEL_RPC_METHOD: &str = "rpc_method";
+
+const RPC_DURATION_BUCKETS: [f64; 12] = [
+    0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
+];
+
+/// Metrics for the rpc-extractor.
+/// Each instance has its own registry, allowing for parallel testing.
+#[derive(Debug, Clone)]
+pub struct Metrics {
+    pub registry: Registry,
+    /// Time it took to fetch data from the RPC endpoint.
+    pub rpc_fetch_duration: HistogramVec,
+    /// Number of errors while fetching data from the RPC endpoint.
+    pub rpc_fetch_errors: IntCounterVec,
+    /// Number of errors while publishing events to NATS.
+    pub nats_publish_errors: IntCounterVec,
+}
+
+impl Metrics {
+    pub fn new() -> Self {
+        let registry = Registry::new_custom(Some(NAMESPACE.to_string()), None)
+            .expect("Could not create prometheus registry");
+
+        let rpc_fetch_duration = register_histogram_vec_with_registry!(
+            HistogramOpts::new(
+                "rpc_fetch_duration_seconds",
+                "Time it took to fetch data from the RPC endpoint."
+            )
+            .buckets(RPC_DURATION_BUCKETS.to_vec()),
+            &[LABEL_RPC_METHOD],
+            registry
+        )
+        .expect("Could not create rpc_fetch_duration_seconds metric");
+
+        let rpc_fetch_errors = register_int_counter_vec_with_registry!(
+            Opts::new(
+                "rpc_fetch_errors_total",
+                "Number of errors while fetching data from the RPC endpoint."
+            ),
+            &[LABEL_RPC_METHOD],
+            registry
+        )
+        .expect("Could not create rpc_fetch_errors_total metric");
+
+        let nats_publish_errors = register_int_counter_vec_with_registry!(
+            Opts::new(
+                "nats_publish_errors_total",
+                "Number of errors while publishing events to NATS."
+            ),
+            &[LABEL_RPC_METHOD],
+            registry
+        )
+        .expect("Could not create nats_publish_errors_total metric");
+
+        Self {
+            registry,
+            rpc_fetch_duration,
+            rpc_fetch_errors,
+            nats_publish_errors,
+        }
+    }
+}
+
+impl Default for Metrics {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/extractors/rpc/tests/common/mod.rs
+++ b/extractors/rpc/tests/common/mod.rs
@@ -1,0 +1,170 @@
+use shared::{
+    corepc_node,
+    log::{self, info},
+    nats_util::NatsArgs,
+    simple_logger::SimpleLogger,
+};
+
+use std::net::TcpListener;
+use std::sync::Once;
+
+use rpc_extractor::Args;
+
+/// Get an available port for the metrics server.
+pub fn get_available_port() -> u16 {
+    TcpListener::bind("127.0.0.1:0")
+        .expect("Failed to bind to port 0")
+        .local_addr()
+        .expect("Failed to get local addr")
+        .port()
+}
+
+static INIT: Once = Once::new();
+
+// 1 second query interval for fast tests
+pub const QUERY_INTERVAL_SECONDS: u64 = 1;
+
+pub fn setup() {
+    INIT.call_once(|| {
+        SimpleLogger::new()
+            .with_level(log::LevelFilter::Trace)
+            .init()
+            .unwrap();
+    });
+}
+
+#[derive(Default)]
+pub struct EnabledRPCsInTest {
+    pub getpeerinfo: bool,
+    pub getmempoolinfo: bool,
+    pub uptime: bool,
+    pub getnettotals: bool,
+    pub getmemoryinfo: bool,
+    pub getaddrmaninfo: bool,
+    pub getchaintxstats: bool,
+    pub getnetworkinfo: bool,
+    pub getblockchaininfo: bool,
+    pub getorphantxs: bool,
+    pub getrawaddrman: bool,
+}
+
+#[allow(dead_code)]
+impl EnabledRPCsInTest {
+    /// Returns an instance with all RPC methods enabled.
+    pub fn all() -> Self {
+        Self {
+            getpeerinfo: true,
+            getmempoolinfo: true,
+            uptime: true,
+            getnettotals: true,
+            getmemoryinfo: true,
+            getaddrmaninfo: true,
+            getchaintxstats: true,
+            getnetworkinfo: true,
+            getblockchaininfo: true,
+            getorphantxs: true,
+            getrawaddrman: true,
+        }
+    }
+
+    /// Returns the names of the enabled RPC methods.
+    /// no need to update a separate list when adding new RPCs.
+    pub fn enabled_methods(&self) -> Vec<&'static str> {
+        let mut methods = Vec::new();
+        if self.getpeerinfo {
+            methods.push("getpeerinfo");
+        }
+        if self.getmempoolinfo {
+            methods.push("getmempoolinfo");
+        }
+        if self.uptime {
+            methods.push("uptime");
+        }
+        if self.getnettotals {
+            methods.push("getnettotals");
+        }
+        if self.getmemoryinfo {
+            methods.push("getmemoryinfo");
+        }
+        if self.getaddrmaninfo {
+            methods.push("getaddrmaninfo");
+        }
+        if self.getchaintxstats {
+            methods.push("getchaintxstats");
+        }
+        if self.getnetworkinfo {
+            methods.push("getnetworkinfo");
+        }
+        if self.getblockchaininfo {
+            methods.push("getblockchaininfo");
+        }
+        if self.getorphantxs {
+            methods.push("getorphantxs");
+        }
+        if self.getrawaddrman {
+            methods.push("getrawaddrman");
+        }
+        methods
+    }
+}
+
+pub fn make_test_args(
+    nats_port: u16,
+    rpc_url: String,
+    cookie_file: String,
+    prometheus_address: String,
+    rpcs: EnabledRPCsInTest,
+) -> Args {
+    Args::new(
+        NatsArgs {
+            address: format!("127.0.0.1:{}", nats_port),
+            username: None,
+            password: None,
+            password_file: None,
+        },
+        log::Level::Trace,
+        rpc_url,
+        cookie_file,
+        QUERY_INTERVAL_SECONDS,
+        QUERY_INTERVAL_SECONDS, // query_interval_less_frequent, but don't fetch less frequently in tests
+        prometheus_address,
+        !rpcs.getpeerinfo,
+        !rpcs.getmempoolinfo,
+        !rpcs.uptime,
+        !rpcs.getnettotals,
+        !rpcs.getmemoryinfo,
+        !rpcs.getaddrmaninfo,
+        !rpcs.getchaintxstats,
+        !rpcs.getnetworkinfo,
+        !rpcs.getblockchaininfo,
+        !rpcs.getorphantxs,
+        !rpcs.getrawaddrman,
+    )
+}
+
+pub fn setup_node(conf: corepc_node::Conf) -> corepc_node::Node {
+    info!("env BITCOIND_EXE={:?}", std::env::var("BITCOIND_EXE"));
+    info!("exe_path={:?}", corepc_node::exe_path());
+
+    if let Ok(exe_path) = corepc_node::exe_path() {
+        info!("Using bitcoind at '{}'", exe_path);
+        return corepc_node::Node::with_conf(exe_path, &conf).unwrap();
+    }
+
+    info!("Trying to download a bitcoind..");
+    corepc_node::Node::from_downloaded_with_conf(&conf).unwrap()
+}
+
+pub fn setup_two_connected_nodes() -> (corepc_node::Node, corepc_node::Node) {
+    // node1 listens for p2p connections
+    let mut node1_conf = corepc_node::Conf::default();
+    node1_conf.p2p = corepc_node::P2P::Yes;
+    let node1 = setup_node(node1_conf);
+
+    // node2 connects to node1
+    let mut node2_conf = corepc_node::Conf::default();
+    node2_conf.p2p = node1.p2p_connect(true).unwrap();
+    let node2 = setup_node(node2_conf);
+
+    (node1, node2)
+}

--- a/extractors/rpc/tests/integration.rs
+++ b/extractors/rpc/tests/integration.rs
@@ -1,6 +1,12 @@
 #![cfg(feature = "nats_integration_tests")]
 #![cfg(feature = "node_integration_tests")]
 
+mod common;
+
+use common::{
+    EnabledRPCsInTest, get_available_port, make_test_args, setup, setup_two_connected_nodes,
+};
+
 use shared::{
     async_nats,
     bitcoin::{
@@ -9,8 +15,6 @@ use shared::{
     },
     corepc_node,
     futures::StreamExt,
-    log::{self, info},
-    nats_util::NatsArgs,
     prost::Message,
     protobuf::{
         event::{Event, event::PeerObserverEvent},
@@ -19,7 +23,6 @@ use shared::{
             NetworkInfo, OrphanTxs, PeerInfos, Uptime,
         },
     },
-    simple_logger::SimpleLogger,
     testing::nats_server::NatsServerForTesting,
     tokio::{
         self, select,
@@ -29,100 +32,9 @@ use shared::{
 };
 
 use std::collections::HashMap;
-use std::sync::Once;
-
-use rpc_extractor::Args;
-
-static INIT: Once = Once::new();
-
-// 1 second query interval for fast tests
-const QUERY_INTERVAL_SECONDS: u64 = 1;
 
 // 5 second check() timeout.
 const TEST_TIMEOUT_SECONDS: u64 = 5;
-
-fn setup() {
-    INIT.call_once(|| {
-        SimpleLogger::new()
-            .with_level(log::LevelFilter::Trace)
-            .init()
-            .unwrap();
-    });
-}
-
-#[derive(Default)]
-struct EnabledRPCsInTest {
-    getpeerinfo: bool,
-    getmempoolinfo: bool,
-    uptime: bool,
-    getnettotals: bool,
-    getmemoryinfo: bool,
-    getaddrmaninfo: bool,
-    getchaintxstats: bool,
-    getnetworkinfo: bool,
-    getblockchaininfo: bool,
-    getorphantxs: bool,
-    getrawaddrman: bool,
-}
-
-fn make_test_args(
-    nats_port: u16,
-    rpc_url: String,
-    cookie_file: String,
-    rpcs: EnabledRPCsInTest,
-) -> Args {
-    Args::new(
-        NatsArgs {
-            address: format!("127.0.0.1:{}", nats_port),
-            username: None,
-            password: None,
-            password_file: None,
-        },
-        log::Level::Trace,
-        rpc_url,
-        cookie_file,
-        QUERY_INTERVAL_SECONDS,
-        QUERY_INTERVAL_SECONDS, // query_interval_less_frequent, but don't fetch less frequently in tests
-        !rpcs.getpeerinfo,
-        !rpcs.getmempoolinfo,
-        !rpcs.uptime,
-        !rpcs.getnettotals,
-        !rpcs.getmemoryinfo,
-        !rpcs.getaddrmaninfo,
-        !rpcs.getchaintxstats,
-        !rpcs.getnetworkinfo,
-        !rpcs.getblockchaininfo,
-        !rpcs.getorphantxs,
-        !rpcs.getrawaddrman,
-    )
-}
-
-fn setup_node(conf: corepc_node::Conf) -> corepc_node::Node {
-    info!("env BITCOIND_EXE={:?}", std::env::var("BITCOIND_EXE"));
-    info!("exe_path={:?}", corepc_node::exe_path());
-
-    if let Ok(exe_path) = corepc_node::exe_path() {
-        info!("Using bitcoind at '{}'", exe_path);
-        return corepc_node::Node::with_conf(exe_path, &conf).unwrap();
-    }
-
-    info!("Trying to download a bitcoind..");
-    corepc_node::Node::from_downloaded_with_conf(&conf).unwrap()
-}
-
-fn setup_two_connected_nodes() -> (corepc_node::Node, corepc_node::Node) {
-    // node1 listens for p2p connections
-    let mut node1_conf = corepc_node::Conf::default();
-    node1_conf.p2p = corepc_node::P2P::Yes;
-    let node1 = setup_node(node1_conf);
-
-    // node2 connects to node1
-    let mut node2_conf = corepc_node::Conf::default();
-    node2_conf.p2p = node1.p2p_connect(true).unwrap();
-    let node2 = setup_node(node2_conf);
-
-    (node1, node2)
-}
 
 async fn check(
     rpcs: EnabledRPCsInTest,
@@ -133,6 +45,7 @@ async fn check(
     let (node1, node2) = setup_two_connected_nodes();
     let nats_server = NatsServerForTesting::new(&[]).await;
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let metrics_port = get_available_port();
 
     let url = node1.rpc_url().replace("http://", "");
     let cookie_file_path = node1.params.cookie_file.display().to_string();
@@ -142,7 +55,13 @@ async fn check(
     sleep(Duration::from_secs(1)).await;
 
     let rpc_extractor_handle = tokio::spawn(async move {
-        let args = make_test_args(nats_server.port, url, cookie_file_path, rpcs);
+        let args = make_test_args(
+            nats_server.port,
+            url,
+            cookie_file_path,
+            format!("127.0.0.1:{}", metrics_port),
+            rpcs,
+        );
         rpc_extractor::run(args, shutdown_rx.clone())
             .await
             .expect("rpc extractor failed");

--- a/extractors/rpc/tests/metrics_integration.rs
+++ b/extractors/rpc/tests/metrics_integration.rs
@@ -1,0 +1,290 @@
+#![cfg(feature = "nats_integration_tests")]
+#![cfg(feature = "node_integration_tests")]
+
+mod common;
+
+use common::{
+    EnabledRPCsInTest, QUERY_INTERVAL_SECONDS, get_available_port, make_test_args, setup,
+    setup_two_connected_nodes,
+};
+
+use shared::{
+    testing::{
+        metrics_fetcher::{fetch_metrics, get_metric_value},
+        nats_server::NatsServerForTesting,
+    },
+    tokio::{self, sync::watch},
+};
+
+/// Verifies the Prometheus metrics server starts and responds to HTTP requests.
+#[tokio::test]
+async fn test_integration_metrics_server_basic() {
+    setup();
+    let (node1, _node2) = setup_two_connected_nodes();
+    let nats_server = NatsServerForTesting::new(&[]).await;
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let metrics_port = get_available_port();
+
+    let rpc_extractor_handle = tokio::spawn(async move {
+        let args = make_test_args(
+            nats_server.port,
+            node1.rpc_url().replace("http://", ""),
+            node1.params.cookie_file.display().to_string(),
+            format!("127.0.0.1:{}", metrics_port),
+            EnabledRPCsInTest {
+                ..Default::default()
+            },
+        );
+        let _ = rpc_extractor::run(args, shutdown_rx.clone()).await;
+    });
+
+    // Wait for the metrics server to start
+    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+
+    // Fetch metrics and verify the server responds
+    let metrics = fetch_metrics(metrics_port, "/metrics");
+    assert!(
+        metrics.is_ok(),
+        "Metrics server should respond: {:?}",
+        metrics
+    );
+
+    // With per-instance registries, metrics only appear after being accessed.
+    // This basic test verifies the server starts and responds.
+    // Actual metric content is verified by other tests that make RPC calls.
+
+    shutdown_tx.send(true).unwrap();
+    rpc_extractor_handle.await.unwrap();
+}
+
+/// Verifies that a successful RPC call records its duration in the histogram.
+#[tokio::test]
+async fn test_integration_metrics_rpc_fetch_duration() {
+    setup();
+    let (node1, _node2) = setup_two_connected_nodes();
+    let nats_server = NatsServerForTesting::new(&[]).await;
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let metrics_port = get_available_port();
+
+    let rpc_extractor_handle = tokio::spawn(async move {
+        let args = make_test_args(
+            nats_server.port,
+            node1.rpc_url().replace("http://", ""),
+            node1.params.cookie_file.display().to_string(),
+            format!("127.0.0.1:{}", metrics_port),
+            EnabledRPCsInTest {
+                uptime: true, // lightweight RPC
+                ..Default::default()
+            },
+        );
+        let _ = rpc_extractor::run(args, shutdown_rx.clone()).await;
+    });
+
+    // Wait for at least one RPC query cycle
+    tokio::time::sleep(tokio::time::Duration::from_secs(QUERY_INTERVAL_SECONDS + 1)).await;
+
+    // Fetch metrics and verify duration was recorded
+    let metrics = fetch_metrics(metrics_port, "/metrics").expect("Should fetch metrics");
+
+    // Check that the histogram count for uptime is at least 1
+    let uptime_count = get_metric_value(
+        &metrics,
+        "rpcextractor_rpc_fetch_duration_seconds_count",
+        "rpc_method",
+        "uptime",
+    );
+    assert!(
+        uptime_count >= 1,
+        "Should have recorded at least one uptime RPC call, got: {}",
+        uptime_count
+    );
+
+    shutdown_tx.send(true).unwrap();
+    rpc_extractor_handle.await.unwrap();
+}
+
+/// Verifies that every enabled RPC method records its duration after one query cycle.
+#[tokio::test]
+async fn test_integration_metrics_all_rpc_methods_duration() {
+    setup();
+    let (node1, _node2) = setup_two_connected_nodes();
+    let nats_server = NatsServerForTesting::new(&[]).await;
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let metrics_port = get_available_port();
+    let rpcs = EnabledRPCsInTest::all();
+
+    let rpc_extractor_handle = tokio::spawn(async move {
+        let args = make_test_args(
+            nats_server.port,
+            node1.rpc_url().replace("http://", ""),
+            node1.params.cookie_file.display().to_string(),
+            format!("127.0.0.1:{}", metrics_port),
+            EnabledRPCsInTest::all(),
+        );
+        let _ = rpc_extractor::run(args, shutdown_rx.clone()).await;
+    });
+
+    // Wait for at least one RPC query cycle
+    tokio::time::sleep(tokio::time::Duration::from_secs(QUERY_INTERVAL_SECONDS + 1)).await;
+
+    // Fetch metrics
+    let metrics = fetch_metrics(metrics_port, "/metrics").expect("Should fetch metrics");
+
+    // Verify that each enabled RPC method has recorded at least one call
+    for method in rpcs.enabled_methods() {
+        let count = get_metric_value(
+            &metrics,
+            "rpcextractor_rpc_fetch_duration_seconds_count",
+            "rpc_method",
+            method,
+        );
+        assert!(
+            count >= 1,
+            "Should have recorded at least one {} RPC call, got: {}",
+            method,
+            count
+        );
+    }
+
+    shutdown_tx.send(true).unwrap();
+    rpc_extractor_handle.await.unwrap();
+}
+
+/// Verifies that a failing RPC call increments the error counter and doesnt record duration (stop_and_discard).
+#[tokio::test]
+async fn test_integration_metrics_rpc_fetch_errors() {
+    setup();
+    let nats_server = NatsServerForTesting::new(&[]).await;
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let metrics_port = get_available_port();
+
+    // Create a temporary cookie file (required by Args validation)
+    let temp_dir = std::env::temp_dir();
+    let cookie_file = temp_dir.join(format!("test_cookie_{}", metrics_port));
+    std::fs::write(&cookie_file, "__cookie__:test").expect("Failed to write cookie file");
+
+    let cookie_file_path = cookie_file.display().to_string();
+    let rpc_extractor_handle = tokio::spawn(async move {
+        let args = make_test_args(
+            nats_server.port,
+            "127.0.0.1:1".to_string(), // Unreachable RPC host
+            cookie_file_path,
+            format!("127.0.0.1:{}", metrics_port),
+            EnabledRPCsInTest {
+                uptime: true, // will fail
+                ..Default::default()
+            },
+        );
+        let _ = rpc_extractor::run(args, shutdown_rx.clone()).await;
+    });
+
+    // Wait for at least one RPC query cycle (which will fail)
+    tokio::time::sleep(tokio::time::Duration::from_secs(QUERY_INTERVAL_SECONDS + 1)).await;
+
+    // Fetch metrics and verify error counter was incremented
+    let metrics = fetch_metrics(metrics_port, "/metrics").expect("Should fetch metrics");
+
+    // Check that the error counter for uptime is at least 1
+    let error_count = get_metric_value(
+        &metrics,
+        "rpcextractor_rpc_fetch_errors_total",
+        "rpc_method",
+        "uptime",
+    );
+    assert!(
+        error_count >= 1,
+        "Should have recorded at least one uptime RPC error, got: {}. Metrics:\n{}",
+        error_count,
+        metrics
+    );
+
+    // Verify that the duration histogram was NOT incremented on error (stop_and_discard)
+    let duration_count = get_metric_value(
+        &metrics,
+        "rpcextractor_rpc_fetch_duration_seconds_count",
+        "rpc_method",
+        "uptime",
+    );
+    assert_eq!(
+        duration_count, 0,
+        "Duration histogram should NOT be incremented on error (stop_and_discard), got: {}",
+        duration_count
+    );
+
+    shutdown_tx.send(true).unwrap();
+    rpc_extractor_handle.await.unwrap();
+
+    // Cleanup
+    let _ = std::fs::remove_file(&cookie_file);
+}
+
+/// Verifies that an auth failure increments the error counter and does not record duration.
+#[tokio::test]
+async fn test_integration_metrics_rpc_fetch_errors_invalid_auth() {
+    setup();
+    let (node1, _node2) = setup_two_connected_nodes();
+    let nats_server = NatsServerForTesting::new(&[]).await;
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let metrics_port = get_available_port();
+
+    // Create a cookie file with invalid credentials
+    let temp_dir = std::env::temp_dir();
+    let invalid_cookie_file = temp_dir.join(format!("invalid_cookie_{}", metrics_port));
+    std::fs::write(&invalid_cookie_file, "__cookie__:invalid_password")
+        .expect("Failed to write invalid cookie file");
+
+    let invalid_cookie_path = invalid_cookie_file.display().to_string();
+    let rpc_url = node1.rpc_url().replace("http://", "");
+    let rpc_extractor_handle = tokio::spawn(async move {
+        let args = make_test_args(
+            nats_server.port,
+            rpc_url,
+            invalid_cookie_path,
+            format!("127.0.0.1:{}", metrics_port),
+            EnabledRPCsInTest {
+                uptime: true, // will fail due to auth
+                ..Default::default()
+            },
+        );
+        let _ = rpc_extractor::run(args, shutdown_rx.clone()).await;
+    });
+
+    // Wait for at least one RPC query cycle (which will fail due to invalid auth)
+    tokio::time::sleep(tokio::time::Duration::from_secs(QUERY_INTERVAL_SECONDS + 1)).await;
+
+    // Fetch metrics and verify error counter was incremented
+    let metrics = fetch_metrics(metrics_port, "/metrics").expect("Should fetch metrics");
+
+    // Check that the error counter for uptime is at least 1
+    let error_count = get_metric_value(
+        &metrics,
+        "rpcextractor_rpc_fetch_errors_total",
+        "rpc_method",
+        "uptime",
+    );
+    assert!(
+        error_count >= 1,
+        "Should have recorded at least one uptime RPC error due to invalid auth, got: {}. Metrics:\n{}",
+        error_count,
+        metrics
+    );
+
+    // Verify that the duration histogram was NOT incremented on error (stop_and_discard)
+    let duration_count = get_metric_value(
+        &metrics,
+        "rpcextractor_rpc_fetch_duration_seconds_count",
+        "rpc_method",
+        "uptime",
+    );
+    assert_eq!(
+        duration_count, 0,
+        "Duration histogram should NOT be incremented on error (stop_and_discard), got: {}",
+        duration_count
+    );
+
+    shutdown_tx.send(true).unwrap();
+    rpc_extractor_handle.await.unwrap();
+
+    // Cleanup
+    let _ = std::fs::remove_file(&invalid_cookie_file);
+}

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -16,7 +16,7 @@ log = "0.4"
 async-nats = { version = "0.46.0", default-features = false } 
 prometheus = "0.14.0"
 lazy_static = "1.5.0"
-tokio = { version = "1.49.0", features = ["rt-multi-thread", "process", "signal"] }
+tokio = { version = "1.50.0", features = ["rt-multi-thread", "process", "signal"] }
 futures = "0.3.31"
 rand = "0.9.2"
 time = { version = "0.3.47", features = ["parsing"] }

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -11,6 +11,7 @@ pub extern crate log;
 pub extern crate prometheus;
 pub extern crate prost;
 pub extern crate rand;
+pub extern crate serde;
 pub extern crate simple_logger;
 pub extern crate tokio;
 

--- a/shared/src/log_matchers.rs
+++ b/shared/src/log_matchers.rs
@@ -172,6 +172,17 @@ struct CommonLogData {
     pub message: String,
 }
 
+/// Returns `true` if `s` is a standalone Bitcoin Core log level bracket token.
+///
+/// Only `LogError()` and `LogWarning()` produce standalone bracket tokens
+/// (`[error]` and `[warning]`). Other Bitcoin Core log levels never appear as
+/// standalone brackets: `LogInfo()` emits no bracket at all, and
+/// `LogDebug()`/`LogTrace()` require a category argument so they produce
+/// `[category]` or `[category:trace]`, never standalone `[debug]` or `[trace]`.
+fn is_standalone_log_level(s: &str) -> bool {
+    matches!(s.to_lowercase().as_str(), "error" | "warning")
+}
+
 fn parse_common_log_data(line: &str) -> CommonLogData {
     let caps = LOG_LINE_REGEX.captures(line);
     if caps.is_none() {
@@ -200,6 +211,11 @@ fn parse_common_log_data(line: &str) -> CommonLogData {
         .captures_iter(metadata)
         .map(|cap| cap[1].to_string())
         .collect();
+
+    // Filter out log level markers. Bitcoin Core uses LogError(), LogWarning(),
+    // etc. which emit [error], [warning], etc. These are log LEVELS, not
+    // threadnames or debug categories.
+    metadata_items.retain(|item| !is_standalone_log_level(item));
 
     // if exists, category is usually the last metadata item
     let mut category = LogDebugCategory::Unknown;
@@ -449,5 +465,72 @@ mod tests {
             return;
         }
         panic!("Expected BlockCheckedLog event");
+    }
+
+    #[test]
+    fn test_log_matcher_error_level_not_treated_as_threadname() {
+        // Bitcoin Core LogError() emits [error] as a log level, not a threadname
+        let log = "2025-10-02T02:31:14Z [error] AcceptBlock: bad-witness-nonce-size, CheckWitnessMalleation : invalid witness reserved value size";
+        let log_event = parse_log_event(log);
+
+        assert_eq!(log_event.category, LogDebugCategory::Unknown as i32);
+        assert_eq!(log_event.threadname, "");
+
+        if let Some(LogEvent::UnknownLogMessage(unknown_log)) = log_event.log_event {
+            assert_eq!(
+                unknown_log.raw_message,
+                "AcceptBlock: bad-witness-nonce-size, CheckWitnessMalleation : invalid witness reserved value size"
+            );
+            return;
+        }
+        panic!("Expected UnknownLogMessage event");
+    }
+
+    #[test]
+    fn test_log_matcher_error_level_with_threadname() {
+        // [threadname] [error] message - error should be filtered, threadname preserved
+        let log = "2025-10-02T02:31:14Z [msghand] [error] some error message";
+        let log_event = parse_log_event(log);
+
+        assert_eq!(log_event.threadname, "msghand");
+        assert_eq!(log_event.category, LogDebugCategory::Unknown as i32);
+
+        if let Some(LogEvent::UnknownLogMessage(unknown_log)) = log_event.log_event {
+            assert_eq!(unknown_log.raw_message, "some error message");
+            return;
+        }
+        panic!("Expected UnknownLogMessage event");
+    }
+
+    #[test]
+    fn test_log_matcher_warning_level_filtered() {
+        let log = "2025-10-02T02:31:14Z [warning] some warning message";
+        let log_event = parse_log_event(log);
+
+        assert_eq!(log_event.threadname, "");
+        assert_eq!(log_event.category, LogDebugCategory::Unknown as i32);
+
+        if let Some(LogEvent::UnknownLogMessage(unknown_log)) = log_event.log_event {
+            assert_eq!(unknown_log.raw_message, "some warning message");
+            return;
+        }
+        panic!("Expected UnknownLogMessage event");
+    }
+
+    #[test]
+    fn test_is_standalone_log_level() {
+        assert!(is_standalone_log_level("error"));
+        assert!(is_standalone_log_level("Error"));
+        assert!(is_standalone_log_level("ERROR"));
+        assert!(is_standalone_log_level("warning"));
+        assert!(is_standalone_log_level("Warning"));
+        // info/debug/trace are NOT standalone bracket tokens in Bitcoin Core
+        assert!(!is_standalone_log_level("info"));
+        assert!(!is_standalone_log_level("debug"));
+        assert!(!is_standalone_log_level("trace"));
+        assert!(!is_standalone_log_level("net"));
+        assert!(!is_standalone_log_level("validation"));
+        assert!(!is_standalone_log_level("msghand"));
+        assert!(!is_standalone_log_level("dnsseed"));
     }
 }

--- a/shared/src/metricserver.rs
+++ b/shared/src/metricserver.rs
@@ -50,6 +50,8 @@ fn handle_request(
     registry: Option<Registry>,
 ) -> Result<(), RequestHandlingError> {
     let mut buffer = [0; 1024];
+    // Intentionally ignore the HTTP method, path, and headers.
+    // The server returns Prometheus metrics for any request, regardless of path.
     let _ = stream.read(&mut buffer)?;
 
     let mut output_buffer = vec![];

--- a/shared/src/testing/metrics_fetcher.rs
+++ b/shared/src/testing/metrics_fetcher.rs
@@ -1,0 +1,61 @@
+//! Utilities for fetching and parsing Prometheus metrics in integration tests.
+
+use std::io::{Read, Write};
+use std::net::TcpStream;
+use std::time::Duration;
+
+/// Fetches metrics from a Prometheus HTTP endpoint using raw TCP.
+///
+/// # Arguments
+/// * `port` - The port to connect to on localhost
+/// * `path` - The HTTP path (e.g., "/" or "/metrics")
+///
+/// # Returns
+/// The raw HTTP response as a string, or an error if the connection fails.
+pub fn fetch_metrics(port: u16, path: &str) -> Result<String, std::io::Error> {
+    let addr = format!("127.0.0.1:{}", port);
+    let mut stream = TcpStream::connect(&addr)?;
+    stream.set_read_timeout(Some(Duration::from_secs(5)))?;
+    stream.set_write_timeout(Some(Duration::from_secs(5)))?;
+
+    let request = format!(
+        "GET {} HTTP/1.1\r\nHost: {}\r\nConnection: close\r\n\r\n",
+        path, addr
+    );
+    stream.write_all(request.as_bytes())?;
+    stream.flush()?;
+
+    let mut response = Vec::new();
+    stream.read_to_end(&mut response)?;
+    Ok(String::from_utf8_lossy(&response).to_string())
+}
+
+/// Convenience wrapper that fetches from the root path "/".
+pub fn fetch_metrics_root(port: u16) -> Result<String, std::io::Error> {
+    fetch_metrics(port, "/")
+}
+
+/// Extracts a numeric metric value from raw Prometheus text output.
+///
+/// Searches for a line containing `{metric_name}{label_name="{label_value}"}`
+/// and returns the numeric value at the end of that line.
+///
+/// # Panics
+/// Panics if the metric is not found or the value cannot be parsed.
+pub fn get_metric_value(
+    metrics_raw: &str,
+    metric_name: &str,
+    label_name: &str,
+    label_value: &str,
+) -> u64 {
+    let search_pattern = format!("{}{{{label_name}=\"{label_value}\"}}", metric_name);
+    metrics_raw
+        .lines()
+        .find(|line| line.contains(&search_pattern))
+        .and_then(|line| {
+            line.split_whitespace()
+                .last()
+                .map(|v| v.parse::<u64>().expect("failed to parse metric value"))
+        })
+        .expect("metric not found")
+}

--- a/shared/src/testing/mod.rs
+++ b/shared/src/testing/mod.rs
@@ -1,3 +1,5 @@
+/// Utilities for fetching Prometheus metrics in integration tests.
+pub mod metrics_fetcher;
 /// A NATS publisher to be used in integration tests.
 pub mod nats_publisher;
 /// A NATS server runnner to be used in integration tests.

--- a/tools/metrics/tests/integration.rs
+++ b/tools/metrics/tests/integration.rs
@@ -36,7 +36,10 @@ use shared::{
     },
     rand::{self, Rng},
     simple_logger::SimpleLogger,
-    testing::{nats_publisher::NatsPublisherForTesting, nats_server::NatsServerForTesting},
+    testing::{
+        metrics_fetcher::fetch_metrics_root, nats_publisher::NatsPublisherForTesting,
+        nats_server::NatsServerForTesting,
+    },
     tokio::{
         self,
         sync::{watch, Mutex},
@@ -48,8 +51,6 @@ use shared::{
 use std::{
     collections::HashMap,
     io::ErrorKind,
-    io::{Read, Write},
-    net::TcpStream,
     sync::{
         atomic::{AtomicU16, Ordering},
         Arc, Once, OnceLock,
@@ -97,31 +98,8 @@ fn make_test_args(nats_port: u16, metrics_port: u16) -> Args {
     )
 }
 
-fn fetch_metrics(port: u16) -> Result<String, std::io::Error> {
-    let addr = format!("127.0.0.1:{}", port);
-    debug!("fetching metrics from {}", addr);
-    let mut stream = TcpStream::connect(addr.clone())?;
-    stream.set_read_timeout(Some(Duration::from_secs(5)))?;
-    stream.set_write_timeout(Some(Duration::from_secs(5)))?;
-
-    let request = format!(
-        "GET / HTTP/1.1\r\nHost: {}\r\nConnection: close\r\n\r\n",
-        addr
-    );
-
-    stream.write_all(request.as_bytes()).unwrap();
-    stream.flush()?;
-
-    // Read the full response until EOF (server closes the connection).
-    let mut response = Vec::new();
-    let mut s = stream;
-    s.read_to_end(&mut response)?;
-
-    Ok(String::from_utf8_lossy(&response).to_string())
-}
-
 fn check_metrics(port: u16, expected: &[&str]) -> Result<bool, std::io::Error> {
-    let metrics_raw = fetch_metrics(port)?;
+    let metrics_raw = fetch_metrics_root(port)?;
 
     println!("HTTP response from metrics server:\n");
     for line in metrics_raw.split("\n") {

--- a/tools/websocket/README.md
+++ b/tools/websocket/README.md
@@ -2,9 +2,7 @@
 
 > publishes events into a websocket as JSON
 
-A peer-observer tool that sends out all events on a websocket. Can be used to
-visualize the events in the browser. The `www/*.html` files implement a few
-visualizations.
+A peer-observer tool that can publish all events on a websocket. Clients start with no subscriptions by default, but can opt in to specific event subjects. This can be used to visualize the events in the browser. The `www/*.html` files implement a few visualizations.
 
 ## Example
 
@@ -44,6 +42,17 @@ Options:
   -V, --version
           Print version
 ```
+
+## Event Filtering with Subscriptions
+
+Clients must subscribe to events they want to receive by sending subscription messages after connecting. Subscriptions allow fine-grained control over event types to reduce bandwidth and processing load.
+
+### How subscriptions work
+
+When a client connects, it receives **no events** until it sends a subscription message. Clients can:
+- Send a JSON subscription message to configure which events to receive
+  - e.g. `{ "ebpf": { "messages": true } }` or `{ "rpc": true }`
+  - All fields default to `false` when omitted, so you only need to include what you want
 
 ## Websocket Picker
 

--- a/tools/websocket/src/error.rs
+++ b/tools/websocket/src/error.rs
@@ -1,4 +1,5 @@
 use shared::async_nats;
+use shared::async_nats::client::FlushErrorKind;
 use shared::async_nats::ConnectErrorKind;
 use shared::log::SetLoggerError;
 use shared::prost::DecodeError;
@@ -13,6 +14,7 @@ pub enum RuntimeError {
     ProtobufDecode(DecodeError),
     NatsSubscribe(async_nats::client::SubscribeError),
     NatsConnect(shared::async_nats::error::Error<ConnectErrorKind>),
+    NatsFlush(shared::async_nats::error::Error<FlushErrorKind>),
 }
 
 impl fmt::Display for RuntimeError {
@@ -23,6 +25,7 @@ impl fmt::Display for RuntimeError {
             RuntimeError::ProtobufDecode(e) => write!(f, "protobuf decode error {}", e),
             RuntimeError::NatsSubscribe(e) => write!(f, "NATS subscribe error {}", e),
             RuntimeError::NatsConnect(e) => write!(f, "NATS connection error {}", e),
+            RuntimeError::NatsFlush(e) => write!(f, "NATS flush error {}", e),
         }
     }
 }
@@ -35,6 +38,7 @@ impl error::Error for RuntimeError {
             RuntimeError::ProtobufDecode(ref e) => Some(e),
             RuntimeError::NatsSubscribe(ref e) => Some(e),
             RuntimeError::NatsConnect(ref e) => Some(e),
+            RuntimeError::NatsFlush(ref e) => Some(e),
         }
     }
 }
@@ -66,5 +70,11 @@ impl From<async_nats::client::SubscribeError> for RuntimeError {
 impl From<shared::async_nats::error::Error<ConnectErrorKind>> for RuntimeError {
     fn from(e: shared::async_nats::error::Error<ConnectErrorKind>) -> Self {
         RuntimeError::NatsConnect(e)
+    }
+}
+
+impl From<shared::async_nats::error::Error<FlushErrorKind>> for RuntimeError {
+    fn from(e: shared::async_nats::error::Error<FlushErrorKind>) -> Self {
+        RuntimeError::NatsFlush(e)
     }
 }

--- a/tools/websocket/src/lib.rs
+++ b/tools/websocket/src/lib.rs
@@ -5,7 +5,10 @@ use shared::futures::{stream::SplitSink, SinkExt, StreamExt};
 use shared::log;
 use shared::nats_util::NatsArgs;
 use shared::prost::Message;
-use shared::protobuf::event::{self, event::PeerObserverEvent};
+use shared::protobuf::{
+    ebpf_extractor::ebpf,
+    event::{self, event::PeerObserverEvent},
+};
 use shared::{
     clap, nats_util,
     tokio::{
@@ -51,8 +54,31 @@ impl Args {
     }
 }
 
-type Clients =
-    Arc<Mutex<HashMap<SocketAddr, SplitSink<WebSocketStream<TcpStream>, TungsteniteMessage>>>>;
+#[derive(Default, Debug)]
+struct ClientSubscriptionsEbpf {
+    messages: bool,
+    mempool: bool,
+    validation: bool,
+    connections: bool,
+    addrman: bool,
+}
+
+// TODO: we could do this more granular (for more detailed filtering)
+// ClientSubscriptionsEbpf is an example of more detailed filtering
+#[derive(Default, Debug)]
+struct ClientSubscriptions {
+    ebpf: ClientSubscriptionsEbpf,
+    p2p: bool,
+    log: bool,
+    rpc: bool,
+}
+
+struct Client {
+    outgoing: SplitSink<WebSocketStream<TcpStream>, TungsteniteMessage>,
+    subscriptions: ClientSubscriptions,
+}
+
+type Clients = Arc<Mutex<HashMap<SocketAddr, Client>>>;
 
 pub async fn run(
     args: Args,
@@ -74,14 +100,7 @@ pub async fn run(
                 match event::Event::decode(msg.payload) {
                     Ok(event) => {
                         if let Some(event) = event.peer_observer_event {
-                            match serde_json::to_string::<PeerObserverEvent>(&event.clone()) {
-                                Ok(msg) => {
-                                    broadcast_to_clients(&msg, &clients).await;
-                                }
-                                Err(e) => {
-                                    log::error!("Could not serialize the message to JSON: {}", e)
-                                }
-                            }
+                            broadcast_to_clients(&event, &clients).await;
                         }
                     }
                     Err(e) => log::error!("Could not deserialize protobuf message: {}", e),
@@ -141,7 +160,14 @@ async fn handle_client(
     let websocket = accept_async(stream).await?;
 
     let (outgoing, mut incoming) = websocket.split();
-    clients.lock().await.insert(addr, outgoing);
+
+    let client = Client {
+        outgoing,
+        // Clients start without any subscriptions
+        subscriptions: ClientSubscriptions::default(),
+    };
+
+    clients.lock().await.insert(addr, client);
 
     log::info!("Client '{}' connected", addr);
 
@@ -165,11 +191,40 @@ async fn handle_client(
     Ok(())
 }
 
-async fn broadcast_to_clients(message: &str, clients: &Clients) {
-    let mut clients = clients.lock().await;
+async fn broadcast_to_clients(event: &PeerObserverEvent, clients: &Clients) {
+    let message = match serde_json::to_string::<PeerObserverEvent>(&event.clone()) {
+        Ok(msg) => msg,
+        Err(e) => {
+            log::error!("Could not serialize the message to JSON: {}", e);
+            return;
+        }
+    };
 
-    for (addr, outgoing) in clients.iter_mut() {
-        if let Err(e) = outgoing.send(TungsteniteMessage::text(message)).await {
+    let mut clients = clients.lock().await;
+    for (addr, client) in clients.iter_mut() {
+        let is_subscribed = match &event {
+            PeerObserverEvent::EbpfExtractor(ebpf) => match &ebpf.ebpf_event {
+                Some(ebpf::EbpfEvent::Message(_)) => client.subscriptions.ebpf.messages,
+                Some(ebpf::EbpfEvent::Connection(_)) => client.subscriptions.ebpf.connections,
+                Some(ebpf::EbpfEvent::Addrman(_)) => client.subscriptions.ebpf.addrman,
+                Some(ebpf::EbpfEvent::Mempool(_)) => client.subscriptions.ebpf.mempool,
+                Some(ebpf::EbpfEvent::Validation(_)) => client.subscriptions.ebpf.validation,
+                None => false,
+            },
+            PeerObserverEvent::RpcExtractor(_) => client.subscriptions.rpc,
+            PeerObserverEvent::P2pExtractor(_) => client.subscriptions.p2p,
+            PeerObserverEvent::LogExtractor(_) => client.subscriptions.log,
+        };
+
+        if !is_subscribed {
+            continue;
+        }
+
+        if let Err(e) = client
+            .outgoing
+            .send(TungsteniteMessage::text(&message))
+            .await
+        {
             log::warn!("Failed to send message to client '{}': {}", addr, e);
         }
     }

--- a/tools/websocket/src/lib.rs
+++ b/tools/websocket/src/lib.rs
@@ -15,7 +15,7 @@ use shared::{
     tokio::{
         self,
         net::{TcpListener, TcpStream},
-        sync::{watch, Mutex},
+        sync::{oneshot, watch, Mutex},
     },
 };
 use std::collections::HashMap;
@@ -84,12 +84,14 @@ type Clients = Arc<Mutex<HashMap<SocketAddr, Client>>>;
 pub async fn run(
     args: Args,
     mut shutdown_rx: watch::Receiver<bool>,
+    bound_addr_tx: Option<oneshot::Sender<SocketAddr>>,
 ) -> Result<(), error::RuntimeError> {
     let nc = nats_util::prepare_connection(&args.nats)?
         .connect(&args.nats.address)
         .await?;
     log::info!("Connected to NATS-server at {}", args.nats.address);
     let mut sub = nc.subscribe("*").await?;
+    nc.flush().await?;
 
     let clients = Arc::new(Mutex::new(HashMap::new()));
 
@@ -114,6 +116,11 @@ pub async fn run(
     let server = TcpListener::bind(args.websocket_address).await?;
     let local_addr = server.local_addr()?;
     log::info!("Started websocket server on {}", local_addr);
+
+    // Notify the caller of the actual bound address (used in tests with port 0).
+    if let Some(tx) = bound_addr_tx {
+        let _ = tx.send(local_addr);
+    }
 
     // Accept WebSocket clients
     loop {

--- a/tools/websocket/src/lib.rs
+++ b/tools/websocket/src/lib.rs
@@ -182,25 +182,35 @@ async fn handle_client(
                         break;
                     }
                     TungsteniteMessage::Text(text) => {
-                        log::debug!("Received message from client '{}': {}", addr, text);
-                        if text.is_empty() {
-                            if let Some(client) = clients.lock().await.get_mut(&addr) {
-                                client.outgoing.close().await?;
+                        let truncated_text: String = text.chars().take(100).collect();
+                        match text.len() {
+                            0 => {
+                                log::warn!(
+                                    "Received empty message from client {addr}. Disconnecting."
+                                )
                             }
-                            clients.lock().await.remove(&addr);
-                            continue;
-                        }
+                            1..512 => match serde_json::from_str::<ClientSubscriptions>(&text) {
+                                Ok(subs) => {
+                                    clients.lock().await.get_mut(&addr).unwrap().subscriptions =
+                                        subs;
+                                    continue;
+                                }
+                                Err(e) => {
+                                    log::warn!("Could not parse client subscriptions from message: '{truncated_text}'; Disconnecting '{addr}' due to error: {e}");
+                                }
+                            },
+                            512.. => {
+                                log::warn!(
+                                    "Received large message '{truncated_text}..' from client {addr}. Disconnecting."
+                                );
+                            }
+                        };
 
-                        match serde_json::from_str::<ClientSubscriptions>(&text) {
-                            Ok(subs) => {
-                                clients.lock().await.get_mut(&addr).unwrap().subscriptions = subs;
-                            }
-                            Err(e) => {
-                                log::warn!("Could not parse client subscriptions from message: {text}; Closing connection to client '{addr}'; Error: {e}");
-                                clients.lock().await.remove(&addr);
-                                break;
-                            }
+                        // if we didn't continue above, we should close the connection to
+                        if let Some(client) = clients.lock().await.get_mut(&addr) {
+                            client.outgoing.close().await?;
                         }
+                        clients.lock().await.remove(&addr);
                     }
                     _ => (),
                 }

--- a/tools/websocket/src/lib.rs
+++ b/tools/websocket/src/lib.rs
@@ -9,6 +9,7 @@ use shared::protobuf::{
     ebpf_extractor::ebpf,
     event::{self, event::PeerObserverEvent},
 };
+use shared::serde::{Deserialize, Serialize};
 use shared::{
     clap, nats_util,
     tokio::{
@@ -54,23 +55,23 @@ impl Args {
     }
 }
 
-#[derive(Default, Debug)]
-struct ClientSubscriptionsEbpf {
-    messages: bool,
-    mempool: bool,
-    validation: bool,
-    connections: bool,
-    addrman: bool,
+#[derive(Default, Debug, Serialize, Deserialize, Clone)]
+#[serde(crate = "shared::serde", default)]
+pub struct ClientSubscriptionsEbpf {
+    pub messages: bool,
+    pub mempool: bool,
+    pub validation: bool,
+    pub connections: bool,
+    pub addrman: bool,
 }
 
-// TODO: we could do this more granular (for more detailed filtering)
-// ClientSubscriptionsEbpf is an example of more detailed filtering
-#[derive(Default, Debug)]
-struct ClientSubscriptions {
-    ebpf: ClientSubscriptionsEbpf,
-    p2p: bool,
-    log: bool,
-    rpc: bool,
+#[derive(Default, Debug, Serialize, Deserialize, Clone)]
+#[serde(crate = "shared::serde", default)]
+pub struct ClientSubscriptions {
+    pub ebpf: ClientSubscriptionsEbpf,
+    pub p2p: bool,
+    pub log: bool,
+    pub rpc: bool,
 }
 
 struct Client {
@@ -174,10 +175,34 @@ async fn handle_client(
     while let Some(msg) = incoming.next().await {
         match msg {
             Ok(m) => {
-                if let TungsteniteMessage::Close(_) = m {
-                    // Remove the client from the shared list if the connection is closed
-                    clients.lock().await.remove(&addr);
-                    break;
+                match m {
+                    TungsteniteMessage::Close(_) => {
+                        // Remove the client from the shared list if the connection is closed
+                        clients.lock().await.remove(&addr);
+                        break;
+                    }
+                    TungsteniteMessage::Text(text) => {
+                        log::debug!("Received message from client '{}': {}", addr, text);
+                        if text.is_empty() {
+                            if let Some(client) = clients.lock().await.get_mut(&addr) {
+                                client.outgoing.close().await?;
+                            }
+                            clients.lock().await.remove(&addr);
+                            continue;
+                        }
+
+                        match serde_json::from_str::<ClientSubscriptions>(&text) {
+                            Ok(subs) => {
+                                clients.lock().await.get_mut(&addr).unwrap().subscriptions = subs;
+                            }
+                            Err(e) => {
+                                log::warn!("Could not parse client subscriptions from message: {text}; Closing connection to client '{addr}'; Error: {e}");
+                                clients.lock().await.remove(&addr);
+                                break;
+                            }
+                        }
+                    }
+                    _ => (),
                 }
             }
             Err(_) => {
@@ -192,7 +217,7 @@ async fn handle_client(
 }
 
 async fn broadcast_to_clients(event: &PeerObserverEvent, clients: &Clients) {
-    let message = match serde_json::to_string::<PeerObserverEvent>(&event.clone()) {
+    let message = match serde_json::to_string::<PeerObserverEvent>(event) {
         Ok(msg) => msg,
         Err(e) => {
             log::error!("Could not serialize the message to JSON: {}", e);
@@ -202,7 +227,7 @@ async fn broadcast_to_clients(event: &PeerObserverEvent, clients: &Clients) {
 
     let mut clients = clients.lock().await;
     for (addr, client) in clients.iter_mut() {
-        let is_subscribed = match &event {
+        let is_subscribed = match event {
             PeerObserverEvent::EbpfExtractor(ebpf) => match &ebpf.ebpf_event {
                 Some(ebpf::EbpfEvent::Message(_)) => client.subscriptions.ebpf.messages,
                 Some(ebpf::EbpfEvent::Connection(_)) => client.subscriptions.ebpf.connections,

--- a/tools/websocket/src/main.rs
+++ b/tools/websocket/src/main.rs
@@ -12,7 +12,9 @@ async fn main() {
     }
 
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
-    let websocket_handle = tokio::spawn(websocket::run(args, shutdown_rx));
+    // No bound address notification needed in production (used in tests to
+    // communicate the OS-assigned port back when binding to port 0).
+    let websocket_handle = tokio::spawn(websocket::run(args, shutdown_rx, None));
 
     tokio::select! {
         _ = signal::ctrl_c() => {

--- a/tools/websocket/tests/integration.rs
+++ b/tools/websocket/tests/integration.rs
@@ -1,26 +1,26 @@
 #![cfg(feature = "nats_integration_tests")]
 
 use shared::{
-    futures::{SinkExt, StreamExt, stream},
+    futures::{stream, SinkExt, StreamExt},
     log,
     nats_subjects::Subject,
     nats_util::NatsArgs,
     prost::Message,
     protobuf::{
         ebpf_extractor::{
-            Ebpf,
             connection::{self, Connection},
             ebpf,
             mempool::{self, Added},
-            message::{self, Metadata, Ping, Pong, message_event::Msg},
+            message::{self, message_event::Msg, Metadata, Ping, Pong},
             validation::{self, BlockConnected},
+            Ebpf,
         },
-        event::{Event, event::PeerObserverEvent},
+        event::{event::PeerObserverEvent, Event},
     },
     simple_logger::SimpleLogger,
     testing::{nats_publisher::NatsPublisherForTesting, nats_server::NatsServerForTesting},
     tokio::{
-        self,
+        self, select,
         sync::{oneshot, watch},
         time::{sleep, timeout},
     },
@@ -88,6 +88,122 @@ fn make_test_args(nats_port: u16) -> Args {
     )
 }
 
+/// Creates a marker event matching the first active subscription type in the
+/// given subscriptions. Returns `(subject, payload, detect)` where `detect` is
+/// a substring that uniquely identifies this marker in the JSON-serialized
+/// websocket message. Returns `None` if no subscriptions are active.
+/// Only covers types exercised by tests: messages and mempool.
+fn marker_for_subscriptions(
+    marker: &str,
+    client_index: usize,
+    subs: &ClientSubscriptions,
+) -> Option<(String, Vec<u8>, String)> {
+    let (subject, ebpf_event, detect) = if subs.ebpf.messages {
+        (
+            Subject::NetMsg,
+            ebpf::EbpfEvent::Message(message::MessageEvent {
+                meta: Metadata {
+                    peer_id: 0,
+                    addr: marker.to_string(),
+                    conn_type: 0,
+                    command: "marker".to_string(),
+                    inbound: false,
+                    size: 0,
+                },
+                msg: Some(Msg::Ping(Ping { value: 0 })),
+            }),
+            marker.to_string(),
+        )
+    } else if subs.ebpf.mempool {
+        // Mempool events have no string fields, so we use a unique fee value
+        // derived from the client index as the detection substring.
+        let fee: i64 = 21212121 + client_index as i64;
+        (
+            Subject::Mempool,
+            ebpf::EbpfEvent::Mempool(mempool::MempoolEvent {
+                event: Some(mempool::mempool_event::Event::Added(Added {
+                    txid: vec![],
+                    vsize: 0,
+                    fee,
+                })),
+            }),
+            fee.to_string(),
+        )
+    } else {
+        return None;
+    };
+
+    let event = Event::new(PeerObserverEvent::EbpfExtractor(Ebpf {
+        ebpf_event: Some(ebpf_event),
+    }))
+    .unwrap();
+
+    Some((subject.to_string(), event.encode_to_vec(), detect))
+}
+
+/// Publishes a marker event to NATS and waits for it to arrive on the given
+/// websocket client stream, proving the full NATS -> server -> client path is
+/// live. The marker is re-published on a short interval because early
+/// publications may arrive before the server has fully registered the client.
+/// Panics on timeout.
+async fn wait_for_marker<S>(
+    publisher: &NatsPublisherForTesting,
+    marker: &str,
+    subject: &str,
+    payload: &[u8],
+    detect: &str,
+    client: &mut S,
+) where
+    S: StreamExt<Item = Result<TungsteniteMessage, tokio_tungstenite::tungstenite::Error>> + Unpin,
+{
+    let mut marker_seen = false;
+    select! {
+        _ = sleep(Duration::from_secs(5)) => {
+            panic!("timed out waiting for pipeline-ready marker '{marker}'");
+        }
+        _ = async {
+            loop {
+                publisher
+                    .publish(subject.to_string(), payload.to_vec())
+                    .await;
+                log::debug!("published pipeline-ready marker '{marker}'");
+
+                // Drain all available messages before re-publishing. Earlier
+                // clients' markers may have accumulated in this stream.
+                loop {
+                    match tokio::time::timeout(Duration::from_millis(50), client.next()).await {
+                        Ok(Some(msg)) => {
+                            let msg = msg.expect("websocket message should be valid");
+                            if msg.to_string().contains(detect) {
+                                log::info!("received pipeline-ready marker: {marker}");
+                                marker_seen = true;
+                                return;
+                            }
+                            // Not our marker; keep draining.
+                        }
+                        Ok(None) => panic!(
+                            "websocket stream closed before pipeline-ready marker '{marker}' arrived"
+                        ),
+                        Err(_) => break, // no more messages, re-publish
+                    }
+                }
+            }
+        } => {}
+    }
+    assert!(
+        marker_seen,
+        "websocket stream closed before pipeline-ready marker '{marker}' arrived"
+    );
+
+    // Drain any extra copies of the marker that arrived while re-publishing.
+    // No real test events have been published yet, so everything here is a
+    // marker (ours or another client's from a prior iteration).
+    sleep(Duration::from_millis(50)).await;
+    while let Ok(Some(msg)) = tokio::time::timeout(Duration::from_millis(10), client.next()).await {
+        let _ = msg.expect("websocket message should be valid");
+    }
+}
+
 async fn publish_and_check_simple(
     events: &[(Subject, Event)],
     expected_events: Vec<&'static str>,
@@ -140,6 +256,53 @@ async fn publish_and_check(events: &[(Subject, Event)], clients: &[ClientConfig]
             .await
             .expect("Should be able to send subscription message");
         clients_stream.push((outgoing, incoming));
+    }
+
+    // Pipeline readiness barrier: wait for EVERY subscribing client to
+    // confirm the full NATS -> websocket server -> client path is live.
+    // Each client is independently inserted into the server's broadcast map
+    // and has its subscriptions applied independently, so one
+    // client receiving a marker does NOT prove the others are registered.
+    // The marker event type must match the client's subscription because
+    // broadcast_to_clients() filters by protobuf variant.
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+
+    for (i, client_config) in clients.iter().enumerate() {
+        if client_config.disconnect {
+            continue;
+        }
+        let marker = format!("PIPELINE_READY:{nanos}:{i}");
+        if let Some((subject, payload, detect)) =
+            marker_for_subscriptions(&marker, i, &client_config.subscriptions)
+        {
+            wait_for_marker(
+                &nats_publisher,
+                &marker,
+                &subject,
+                &payload,
+                &detect,
+                &mut clients_stream[i].1,
+            )
+            .await;
+        }
+    }
+
+    // Final drain: flush any markers that leaked to other clients during
+    // the sequential readiness checks above.
+    sleep(Duration::from_millis(50)).await;
+    for (i, client_config) in clients.iter().enumerate() {
+        if client_config.disconnect {
+            continue;
+        }
+        let incoming = &mut clients_stream[i].1;
+        while let Ok(Some(msg)) =
+            tokio::time::timeout(Duration::from_millis(10), incoming.next()).await
+        {
+            let _ = msg.expect("websocket message should be valid");
+        }
     }
 
     for (subject, event) in events.iter() {

--- a/tools/websocket/tests/integration.rs
+++ b/tools/websocket/tests/integration.rs
@@ -1,43 +1,35 @@
 #![cfg(feature = "nats_integration_tests")]
 
 use shared::{
-    futures::{stream, SinkExt, StreamExt},
-    log::{self, warn},
+    futures::{SinkExt, StreamExt, stream},
+    log,
     nats_subjects::Subject,
     nats_util::NatsArgs,
     prost::Message,
     protobuf::{
         ebpf_extractor::{
+            Ebpf,
             connection::{self, Connection},
             ebpf,
             mempool::{self, Added},
-            message::{self, message_event::Msg, Metadata, Ping, Pong},
+            message::{self, Metadata, Ping, Pong, message_event::Msg},
             validation::{self, BlockConnected},
-            Ebpf,
         },
-        event::{event::PeerObserverEvent, Event},
+        event::{Event, event::PeerObserverEvent},
     },
-    rand::{self, Rng},
     simple_logger::SimpleLogger,
     testing::{nats_publisher::NatsPublisherForTesting, nats_server::NatsServerForTesting},
     tokio::{
         self,
-        sync::{watch, Mutex},
+        sync::{oneshot, watch},
         time::{sleep, timeout},
     },
 };
 use tokio_tungstenite::tungstenite::Message as TungsteniteMessage;
 
-use std::{
-    io::ErrorKind,
-    sync::{
-        atomic::{AtomicU16, Ordering},
-        Arc, Once, OnceLock,
-    },
-    time::Duration,
-};
+use std::{sync::Once, time::Duration};
 
-use websocket::{error::RuntimeError, Args, ClientSubscriptions, ClientSubscriptionsEbpf};
+use websocket::{Args, ClientSubscriptions, ClientSubscriptionsEbpf};
 
 const SUBSCRIBE_NONE: ClientSubscriptions = ClientSubscriptions {
     ebpf: ClientSubscriptionsEbpf {
@@ -74,32 +66,16 @@ struct ClientConfig {
 
 static INIT: Once = Once::new();
 
-static NEXT_WEBSOCKET_PORT: OnceLock<AtomicU16> = OnceLock::new();
-
-fn setup() -> u16 {
+fn setup() {
     INIT.call_once(|| {
         SimpleLogger::new()
             .with_level(log::LevelFilter::Trace)
             .init()
             .unwrap();
-
-        let mut rng = rand::rng();
-
-        // choose start ports from the ephemeral port range
-        let websocket_start = rng.random_range(49152..65500);
-        NEXT_WEBSOCKET_PORT
-            .set(AtomicU16::new(websocket_start))
-            .unwrap();
     });
-
-    let websocket_port = NEXT_WEBSOCKET_PORT
-        .get()
-        .unwrap()
-        .fetch_add(1, Ordering::SeqCst);
-    websocket_port
 }
 
-fn make_test_args(nats_port: u16, websocket_port: u16) -> Args {
+fn make_test_args(nats_port: u16) -> Args {
     Args::new(
         NatsArgs {
             address: format!("127.0.0.1:{}", nats_port),
@@ -107,7 +83,7 @@ fn make_test_args(nats_port: u16, websocket_port: u16) -> Args {
             password: None,
             password_file: None,
         },
-        format!("127.0.0.1:{}", websocket_port),
+        "127.0.0.1:0".to_string(),
         log::Level::Trace,
     )
 }
@@ -131,52 +107,27 @@ async fn publish_and_check_simple(
 }
 
 async fn publish_and_check(events: &[(Subject, Event)], clients: &[ClientConfig]) {
-    let initial_websocket_port = setup();
-    let websocket_port: Arc<Mutex<u16>> = Arc::new(Mutex::new(initial_websocket_port));
+    setup();
 
     let nats_server = NatsServerForTesting::new(&[]).await;
     let nats_publisher = NatsPublisherForTesting::new(nats_server.port).await;
 
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
-    let websocket_port_clone = websocket_port.clone();
+    let (bound_addr_tx, bound_addr_rx) = oneshot::channel();
+    let args = make_test_args(nats_server.port);
     let websocket_handle = tokio::spawn(async move {
-        loop {
-            let port: u16;
-            {
-                port = *websocket_port_clone.lock().await;
-            }
-
-            let args = make_test_args(nats_server.port, port);
-            match websocket::run(args, shutdown_rx.clone()).await {
-                Ok(_) => break,
-                Err(e) => match e {
-                    RuntimeError::Io(e) => match e.kind() {
-                        ErrorKind::AddrInUse => {
-                            let new_port = NEXT_WEBSOCKET_PORT
-                                .get()
-                                .unwrap()
-                                .fetch_add(1, Ordering::SeqCst);
-                            warn!(
-                                "Port {} seems to be already in use. Trying port {} next..",
-                                port, new_port
-                            );
-                            let mut port = websocket_port_clone.lock().await;
-                            *port = new_port;
-                        }
-                        _ => panic!("Couldn not start websocket tool: {}", e),
-                    },
-                    _ => panic!("Couldn not start websocket tool: {}", e),
-                },
-            }
-        }
+        websocket::run(args, shutdown_rx, Some(bound_addr_tx))
+            .await
+            .expect("websocket tool should start successfully");
     });
-    // allow the websocket tool to start
-    sleep(Duration::from_secs(1)).await;
 
-    let port = websocket_port.lock().await;
+    let bound_addr = bound_addr_rx
+        .await
+        .expect("Should receive bound address from websocket tool");
+
     let mut clients_stream = vec![];
     for client_config in clients {
-        let (ws_stream, _) = tokio_tungstenite::connect_async(format!("ws://127.0.0.1:{}", port))
+        let (ws_stream, _) = tokio_tungstenite::connect_async(format!("ws://{}", bound_addr))
             .await
             .expect("Should be able to connect to websocket");
         let (mut outgoing, incoming) = ws_stream.split();
@@ -242,50 +193,24 @@ async fn publish_and_check(events: &[(Subject, Event)], clients: &[ClientConfig]
 }
 
 async fn custom_message_check(message: &str) {
-    let initial_websocket_port = setup();
-    let websocket_port: Arc<Mutex<u16>> = Arc::new(Mutex::new(initial_websocket_port));
+    setup();
 
     let nats_server = NatsServerForTesting::new(&[]).await;
 
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
-    let websocket_port_clone = websocket_port.clone();
+    let (bound_addr_tx, bound_addr_rx) = oneshot::channel();
+    let args = make_test_args(nats_server.port);
     let websocket_handle = tokio::spawn(async move {
-        loop {
-            let port: u16;
-            {
-                port = *websocket_port_clone.lock().await;
-            }
-
-            let args = make_test_args(nats_server.port, port);
-            match websocket::run(args, shutdown_rx.clone()).await {
-                Ok(_) => break,
-                Err(e) => match e {
-                    RuntimeError::Io(e) => match e.kind() {
-                        ErrorKind::AddrInUse => {
-                            let new_port = NEXT_WEBSOCKET_PORT
-                                .get()
-                                .unwrap()
-                                .fetch_add(1, Ordering::SeqCst);
-                            warn!(
-                                "Port {} seems to be already in use. Trying port {} next..",
-                                port, new_port
-                            );
-                            let mut port = websocket_port_clone.lock().await;
-                            *port = new_port;
-                        }
-                        _ => panic!("Couldn not start websocket tool: {}", e),
-                    },
-                    _ => panic!("Couldn not start websocket tool: {}", e),
-                },
-            }
-        }
+        websocket::run(args, shutdown_rx, Some(bound_addr_tx))
+            .await
+            .expect("websocket tool should start successfully");
     });
-    // allow the websocket tool to start
-    sleep(Duration::from_secs(1)).await;
 
-    let port = websocket_port.lock().await;
+    let bound_addr = bound_addr_rx
+        .await
+        .expect("Should receive bound address from websocket tool");
 
-    let (ws_stream, _) = tokio_tungstenite::connect_async(format!("ws://127.0.0.1:{}", port))
+    let (ws_stream, _) = tokio_tungstenite::connect_async(format!("ws://{}", bound_addr))
         .await
         .expect("Should be able to connect to websocket");
     let (mut outgoing, mut incoming) = ws_stream.split();

--- a/tools/websocket/tests/integration.rs
+++ b/tools/websocket/tests/integration.rs
@@ -1,28 +1,32 @@
 #![cfg(feature = "nats_integration_tests")]
 
 use shared::{
-    futures::StreamExt,
+    futures::{stream, SinkExt, StreamExt},
     log::{self, warn},
     nats_subjects::Subject,
     nats_util::NatsArgs,
     prost::Message,
-    protobuf::ebpf_extractor::{
-        connection::{self, Connection},
-        ebpf,
-        message::{self, message_event::Msg, Metadata, Ping, Pong},
-        Ebpf,
+    protobuf::{
+        ebpf_extractor::{
+            connection::{self, Connection},
+            ebpf,
+            mempool::{self, Added},
+            message::{self, message_event::Msg, Metadata, Ping, Pong},
+            validation::{self, BlockConnected},
+            Ebpf,
+        },
+        event::{event::PeerObserverEvent, Event},
     },
-    protobuf::event::{event::PeerObserverEvent, Event},
     rand::{self, Rng},
     simple_logger::SimpleLogger,
-    testing::nats_publisher::NatsPublisherForTesting,
-    testing::nats_server::NatsServerForTesting,
+    testing::{nats_publisher::NatsPublisherForTesting, nats_server::NatsServerForTesting},
     tokio::{
         self,
         sync::{watch, Mutex},
-        time::sleep,
+        time::{sleep, timeout},
     },
 };
+use tokio_tungstenite::tungstenite::Message as TungsteniteMessage;
 
 use std::{
     io::ErrorKind,
@@ -33,7 +37,40 @@ use std::{
     time::Duration,
 };
 
-use websocket::{error::RuntimeError, Args};
+use websocket::{error::RuntimeError, Args, ClientSubscriptions, ClientSubscriptionsEbpf};
+
+const SUBSCRIBE_NONE: ClientSubscriptions = ClientSubscriptions {
+    ebpf: ClientSubscriptionsEbpf {
+        messages: false,
+        mempool: false,
+        validation: false,
+        connections: false,
+        addrman: false,
+    },
+    p2p: false,
+    log: false,
+    rpc: false,
+};
+
+const SUBSCRIBE_ALL: ClientSubscriptions = ClientSubscriptions {
+    ebpf: ClientSubscriptionsEbpf {
+        messages: true,
+        mempool: true,
+        validation: true,
+        connections: true,
+        addrman: true,
+    },
+    p2p: true,
+    log: true,
+    rpc: true,
+};
+
+#[derive(Debug, Clone)]
+struct ClientConfig {
+    subscriptions: ClientSubscriptions,
+    expected_events: Vec<&'static str>,
+    disconnect: bool, // whether to disconnect this client before receiving messages
+}
 
 static INIT: Once = Once::new();
 
@@ -75,13 +112,25 @@ fn make_test_args(nats_port: u16, websocket_port: u16) -> Args {
     )
 }
 
-async fn publish_and_check(
-    events: &[Event],
-    subject: Subject,
-    expected: &[&str],
-    num_clients: u8,
-    disconnect_client: Option<u8>, // which client to disconnect
+async fn publish_and_check_simple(
+    events: &[(Subject, Event)],
+    expected_events: Vec<&'static str>,
+    num_clients: Option<u8>,
 ) {
+    let num_clients = num_clients.unwrap_or(1);
+    let clients = vec![
+        ClientConfig {
+            subscriptions: SUBSCRIBE_ALL.clone(),
+            expected_events: expected_events.to_vec(),
+            disconnect: false,
+        };
+        num_clients as usize
+    ];
+
+    publish_and_check(events, clients.as_slice()).await;
+}
+
+async fn publish_and_check(events: &[(Subject, Event)], clients: &[ClientConfig]) {
     let initial_websocket_port = setup();
     let websocket_port: Arc<Mutex<u16>> = Arc::new(Mutex::new(initial_websocket_port));
 
@@ -125,46 +174,68 @@ async fn publish_and_check(
     sleep(Duration::from_secs(1)).await;
 
     let port = websocket_port.lock().await;
-    let mut clients = vec![];
-    for _ in 0..num_clients {
+    let mut clients_stream = vec![];
+    for client_config in clients {
         let (ws_stream, _) = tokio_tungstenite::connect_async(format!("ws://127.0.0.1:{}", port))
             .await
             .expect("Should be able to connect to websocket");
-        clients.push(ws_stream)
+        let (mut outgoing, incoming) = ws_stream.split();
+        outgoing
+            .send(TungsteniteMessage::Text(
+                serde_json::to_string(&client_config.subscriptions)
+                    .unwrap()
+                    .into(),
+            ))
+            .await
+            .expect("Should be able to send subscription message");
+        clients_stream.push((outgoing, incoming));
     }
 
-    for event in events.iter() {
+    for (subject, event) in events.iter() {
         log::debug!("publishing: {:?}", event);
         nats_publisher
             .publish(subject.to_string(), event.encode_to_vec())
             .await;
     }
 
-    if let Some(idx) = disconnect_client {
-        clients[idx as usize]
-            .close(None)
-            .await
-            .expect("Should be able to close a client");
+    for (i, client_config) in clients.iter().enumerate() {
+        if client_config.disconnect {
+            let outgoing = &mut clients_stream[i].0;
+            outgoing
+                .close()
+                .await
+                .expect("Should be able to close a client");
+        }
     }
 
-    sleep(Duration::from_millis(100)).await;
-
-    assert_eq!(events.len(), expected.len());
-    for (i, client) in clients.iter_mut().enumerate() {
-        if let Some(idx) = disconnect_client {
-            // if we closed this client, we can skip it here as we don't expect it to have all events
-            if i == idx as usize {
-                continue;
+    stream::iter(clients_stream)
+        .enumerate()
+        .map(async |(i, (_, mut incoming))| {
+            let client_config = &clients[i];
+            if client_config.disconnect {
+                // if we closed this client, we can skip it here as we don't expect it to have all events
+                return;
             }
-        }
-        for expected in expected.iter() {
-            if let Some(msg) = client.next().await {
-                let msg = msg.unwrap();
-                println!("data: {}", msg);
+
+            let mut messages = vec![];
+            timeout(Duration::from_secs(1), async {
+                while let Some(msg) = incoming.next().await {
+                    messages.push(msg.unwrap());
+                }
+            })
+            .await
+            .unwrap_or(());
+
+            assert_eq!(client_config.expected_events.len(), messages.len()); // not less, not more
+
+            for (i, expected) in client_config.expected_events.iter().enumerate() {
+                let msg = &messages[i];
                 assert_eq!(*expected, msg.to_string());
             }
-        }
-    }
+        })
+        .buffer_unordered(clients.len())
+        .collect::<Vec<_>>()
+        .await;
 
     shutdown_tx.send(true).unwrap();
     websocket_handle.await.unwrap();
@@ -174,22 +245,34 @@ async fn publish_and_check(
 async fn test_integration_websocket_conn_inbound() {
     println!("test that inbound connections work");
 
-    publish_and_check(&[Event::new(PeerObserverEvent::EbpfExtractor(Ebpf {
-        ebpf_event: Some(ebpf::EbpfEvent::Connection(connection::ConnectionEvent {
-            event: Some(connection::connection_event::Event::Inbound(
-                connection::InboundConnection {
-                    conn: Connection {
-                        addr: "127.0.0.1:8333".to_string(),
-                        conn_type: 1,
-                        network: 2,
-                        peer_id: 7,
-                    },
-                    existing_connections: 123,
-                },
-            )),
-        }))
-    }))
-    .unwrap()], Subject::NetConn, &[r#"{"EbpfExtractor":{"ebpf_event":{"Connection":{"event":{"Inbound":{"conn":{"peer_id":7,"addr":"127.0.0.1:8333","conn_type":1,"network":2},"existing_connections":123}}}}}}"#],1, None).await;
+    publish_and_check(
+        &[(
+            Subject::NetConn,
+            Event::new(PeerObserverEvent::EbpfExtractor(Ebpf {
+                ebpf_event: Some(ebpf::EbpfEvent::Connection(connection::ConnectionEvent {
+                    event: Some(connection::connection_event::Event::Inbound(
+                        connection::InboundConnection {
+                            conn: Connection {
+                                addr: "127.0.0.1:8333".to_string(),
+                                conn_type: 1,
+                                network: 2,
+                                peer_id: 7,
+                            },
+                            existing_connections: 123,
+                        },
+                    )),
+                })),
+            }))
+            .unwrap(),
+        )],
+        &[ClientConfig {
+            subscriptions: SUBSCRIBE_ALL.clone(),
+            expected_events: vec![
+                r#"{"EbpfExtractor":{"ebpf_event":{"Connection":{"event":{"Inbound":{"conn":{"peer_id":7,"addr":"127.0.0.1:8333","conn_type":1,"network":2},"existing_connections":123}}}}}}"#,
+            ],
+            disconnect: false,
+        }],
+    ).await;
 }
 
 #[tokio::test]
@@ -198,7 +281,7 @@ async fn test_integration_websocket_p2p_message_ping() {
 
     publish_and_check(
         &[
-            Event::new(PeerObserverEvent::EbpfExtractor(Ebpf {
+            (Subject::NetMsg, Event::new(PeerObserverEvent::EbpfExtractor(Ebpf {
                 ebpf_event: Some(ebpf::EbpfEvent::Message(message::MessageEvent  {
                     meta: Metadata {
                         peer_id: 0,
@@ -211,8 +294,8 @@ async fn test_integration_websocket_p2p_message_ping() {
                     msg: Some(Msg::Ping(Ping { value: 1 })),
                 }))
             }))
-            .unwrap(),
-            Event::new(PeerObserverEvent::EbpfExtractor(Ebpf {
+            .unwrap()),
+            (Subject::NetMsg, Event::new(PeerObserverEvent::EbpfExtractor(Ebpf {
                 ebpf_event: Some(ebpf::EbpfEvent::Message(message::MessageEvent  {
                     meta: Metadata {
                         peer_id: 0,
@@ -225,13 +308,17 @@ async fn test_integration_websocket_p2p_message_ping() {
                     msg: Some(Msg::Pong(Pong { value: 1 })),
                 }))
             }))
-            .unwrap(),
+            .unwrap(),)
         ],
-        Subject::NetMsg,
-        &[r#"{"EbpfExtractor":{"ebpf_event":{"Message":{"meta":{"peer_id":0,"addr":"127.0.0.1:8333","conn_type":1,"command":"ping","inbound":true,"size":8},"msg":{"Ping":{"value":1}}}}}}"#,
-            r#"{"EbpfExtractor":{"ebpf_event":{"Message":{"meta":{"peer_id":0,"addr":"127.0.0.1:8333","conn_type":1,"command":"pong","inbound":false,"size":8},"msg":{"Pong":{"value":1}}}}}}"#],
-        1,
-        None
+        &[
+          ClientConfig {
+              subscriptions: SUBSCRIBE_ALL.clone(),
+              expected_events: vec![
+                  r#"{"EbpfExtractor":{"ebpf_event":{"Message":{"meta":{"peer_id":0,"addr":"127.0.0.1:8333","conn_type":1,"command":"ping","inbound":true,"size":8},"msg":{"Ping":{"value":1}}}}}}"#,
+                  r#"{"EbpfExtractor":{"ebpf_event":{"Message":{"meta":{"peer_id":0,"addr":"127.0.0.1:8333","conn_type":1,"command":"pong","inbound":false,"size":8},"msg":{"Pong":{"value":1}}}}}}"#],
+              disconnect: false,
+          },
+        ]
     )
     .await;
 }
@@ -240,9 +327,9 @@ async fn test_integration_websocket_p2p_message_ping() {
 async fn test_integration_websocket_multi_client() {
     println!("test that multiple clients all receive the messages");
 
-    publish_and_check(
+    publish_and_check_simple(
         &[
-            Event::new(PeerObserverEvent::EbpfExtractor(Ebpf {
+            (Subject::NetMsg, Event::new(PeerObserverEvent::EbpfExtractor(Ebpf {
                 ebpf_event: Some(ebpf::EbpfEvent::Message(message::MessageEvent  {
                     meta: Metadata {
                         peer_id: 0,
@@ -255,8 +342,8 @@ async fn test_integration_websocket_multi_client() {
                     msg: Some(Msg::Ping(Ping { value: 1 })),
                 }))
             }))
-            .unwrap(),
-            Event::new(PeerObserverEvent::EbpfExtractor(Ebpf {
+            .unwrap()),
+            (Subject::NetMsg, Event::new(PeerObserverEvent::EbpfExtractor(Ebpf {
                 ebpf_event: Some(ebpf::EbpfEvent::Message(message::MessageEvent  {
                     meta: Metadata {
                         peer_id: 0,
@@ -269,13 +356,11 @@ async fn test_integration_websocket_multi_client() {
                     msg: Some(Msg::Pong(Pong { value: 1 })),
                 }))
             }))
-            .unwrap(),
+            .unwrap()),
         ],
-        Subject::NetMsg,
-        &[r#"{"EbpfExtractor":{"ebpf_event":{"Message":{"meta":{"peer_id":0,"addr":"127.0.0.1:8333","conn_type":1,"command":"ping","inbound":true,"size":8},"msg":{"Ping":{"value":1}}}}}}"#,
+        vec![r#"{"EbpfExtractor":{"ebpf_event":{"Message":{"meta":{"peer_id":0,"addr":"127.0.0.1:8333","conn_type":1,"command":"ping","inbound":true,"size":8},"msg":{"Ping":{"value":1}}}}}}"#,
             r#"{"EbpfExtractor":{"ebpf_event":{"Message":{"meta":{"peer_id":0,"addr":"127.0.0.1:8333","conn_type":1,"command":"pong","inbound":false,"size":8},"msg":{"Pong":{"value":1}}}}}}"#],
-        12,
-        None
+        Some(12),
     )
     .await;
 }
@@ -287,7 +372,7 @@ async fn test_integration_websocket_closed_client() {
     );
 
     publish_and_check(
-        &[Event::new(PeerObserverEvent::EbpfExtractor(Ebpf {
+        &[(Subject::NetConn, Event::new(PeerObserverEvent::EbpfExtractor(Ebpf {
             ebpf_event: Some(ebpf::EbpfEvent::Connection(connection::ConnectionEvent {
                 event: Some(connection::connection_event::Event::Outbound(
                     connection::OutboundConnection {
@@ -302,11 +387,79 @@ async fn test_integration_websocket_closed_client() {
                 )),
             }))
         }))
-        .unwrap()],
-        Subject::NetConn,
-        &[r#"{"EbpfExtractor":{"ebpf_event":{"Connection":{"event":{"Outbound":{"conn":{"peer_id":11,"addr":"1.1.1.1:48333","conn_type":2,"network":3},"existing_connections":321}}}}}}"#],
-        4,
-        Some(2)
+        .unwrap())],
+        &[
+            ClientConfig {
+                subscriptions: SUBSCRIBE_ALL.clone(),
+                expected_events: vec![
+                    r#"{"EbpfExtractor":{"ebpf_event":{"Connection":{"event":{"Outbound":{"conn":{"peer_id":11,"addr":"1.1.1.1:48333","conn_type":2,"network":3},"existing_connections":321}}}}}}"#,
+                ],
+                disconnect: false,
+            },
+              ClientConfig {
+                subscriptions: SUBSCRIBE_ALL.clone(),
+                expected_events: vec![],
+                disconnect: true,
+            },
+              ClientConfig {
+                subscriptions: SUBSCRIBE_ALL.clone(),
+                expected_events: vec![
+                    r#"{"EbpfExtractor":{"ebpf_event":{"Connection":{"event":{"Outbound":{"conn":{"peer_id":11,"addr":"1.1.1.1:48333","conn_type":2,"network":3},"existing_connections":321}}}}}}"#,
+                ],
+                disconnect: false,
+            },
+        ],
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_integration_websocket_specific_subjects() {
+    println!("test that we can subscribe to specific subjects and only receive those events");
+
+    let mut subscriptions = SUBSCRIBE_NONE.clone();
+    subscriptions.ebpf.mempool = true;
+
+    publish_and_check(
+        &[
+            (Subject::Mempool, Event::new(PeerObserverEvent::EbpfExtractor(Ebpf {
+                ebpf_event: Some(ebpf::EbpfEvent::Mempool(mempool::MempoolEvent {
+                    event: Some(mempool::mempool_event::Event::Added(Added {
+                        txid: vec![76, 70, 231],
+                        vsize: 175,
+                        fee: 358,
+                    })),
+                }))
+            }))
+            .unwrap()),
+            (Subject::Validation, Event::new(PeerObserverEvent::EbpfExtractor(Ebpf {
+                ebpf_event: Some(ebpf::EbpfEvent::Validation(validation::ValidationEvent {
+                    event: Some(validation::validation_event::Event::BlockConnected(BlockConnected {
+                        hash: vec![1, 2, 3, 4, 5],
+                        height: 800000,
+                        transactions: 2500,
+                        inputs: 5000,
+                        sigops: 20000,
+                        connection_time: 1500000000,
+                    })),
+                }))
+            }))
+            .unwrap()),
+        ],
+        &[
+              ClientConfig {
+                  subscriptions,
+                  expected_events: vec![
+                      r#"{"EbpfExtractor":{"ebpf_event":{"Mempool":{"event":{"Added":{"txid":[76,70,231],"vsize":175,"fee":358}}}}}}"#,
+                  ],
+                  disconnect: false,
+              },
+              ClientConfig {
+                  subscriptions: SUBSCRIBE_NONE.clone(),
+                  expected_events: vec![],
+                  disconnect: false,
+              },
+        ]
     )
     .await;
 }

--- a/tools/websocket/tests/integration.rs
+++ b/tools/websocket/tests/integration.rs
@@ -241,6 +241,75 @@ async fn publish_and_check(events: &[(Subject, Event)], clients: &[ClientConfig]
     websocket_handle.await.unwrap();
 }
 
+async fn custom_message_check(message: &str) {
+    let initial_websocket_port = setup();
+    let websocket_port: Arc<Mutex<u16>> = Arc::new(Mutex::new(initial_websocket_port));
+
+    let nats_server = NatsServerForTesting::new(&[]).await;
+
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let websocket_port_clone = websocket_port.clone();
+    let websocket_handle = tokio::spawn(async move {
+        loop {
+            let port: u16;
+            {
+                port = *websocket_port_clone.lock().await;
+            }
+
+            let args = make_test_args(nats_server.port, port);
+            match websocket::run(args, shutdown_rx.clone()).await {
+                Ok(_) => break,
+                Err(e) => match e {
+                    RuntimeError::Io(e) => match e.kind() {
+                        ErrorKind::AddrInUse => {
+                            let new_port = NEXT_WEBSOCKET_PORT
+                                .get()
+                                .unwrap()
+                                .fetch_add(1, Ordering::SeqCst);
+                            warn!(
+                                "Port {} seems to be already in use. Trying port {} next..",
+                                port, new_port
+                            );
+                            let mut port = websocket_port_clone.lock().await;
+                            *port = new_port;
+                        }
+                        _ => panic!("Couldn not start websocket tool: {}", e),
+                    },
+                    _ => panic!("Couldn not start websocket tool: {}", e),
+                },
+            }
+        }
+    });
+    // allow the websocket tool to start
+    sleep(Duration::from_secs(1)).await;
+
+    let port = websocket_port.lock().await;
+
+    let (ws_stream, _) = tokio_tungstenite::connect_async(format!("ws://127.0.0.1:{}", port))
+        .await
+        .expect("Should be able to connect to websocket");
+    let (mut outgoing, mut incoming) = ws_stream.split();
+
+    outgoing
+        .send(TungsteniteMessage::Text(message.into()))
+        .await
+        .expect("Should be able to send custom message");
+
+    let msg = incoming
+        .next()
+        .await
+        .expect("No message received")
+        .expect("Error in message");
+    assert!(
+        matches!(msg, TungsteniteMessage::Close(_)),
+        "Expected Close message, got {:?}",
+        msg
+    );
+
+    shutdown_tx.send(true).unwrap();
+    websocket_handle.await.unwrap();
+}
+
 #[tokio::test]
 async fn test_integration_websocket_conn_inbound() {
     println!("test that inbound connections work");
@@ -462,4 +531,12 @@ async fn test_integration_websocket_specific_subjects() {
         ]
     )
     .await;
+}
+
+#[tokio::test]
+async fn test_integration_websocket_invalid_message_disconnect() {
+    println!("Check that we disconnect on invalid, empty, and large messages");
+    custom_message_check("").await;
+    custom_message_check("aaaaaaa").await;
+    custom_message_check(&"a".repeat(513)).await;
 }

--- a/tools/websocket/www/addrrelay.html
+++ b/tools/websocket/www/addrrelay.html
@@ -337,6 +337,7 @@
   window.onload = (event) => {
     cleanUpClosedPeers()
     runUnitTests()
+    updateSubscriptions({ ebpf: { messages: true, connections: true } })
     initWebsocketPicker("websockets.json", "websocket-picker", processWebsocketMessage, handleWebsocketReset)
   };
 

--- a/tools/websocket/www/js/websocket-picker.js
+++ b/tools/websocket/www/js/websocket-picker.js
@@ -13,6 +13,19 @@ var g_messageCallback;
 var g_resetCallback;
 var g_ws;
 
+var subscriptions = {
+  ebpf: {
+    messages: false,
+    mempool: false,
+    validation: false,
+    connections: false,
+    addrman: false
+  },
+  p2p: false,
+  log: false,
+  rpc: false
+};
+
 function switchWebsocket(url) {
   // close any eventually existing websockets
   if (g_ws) {
@@ -26,8 +39,18 @@ function switchWebsocket(url) {
   g_ws = new WebSocket(url);
   g_ws.addEventListener("open", (e) => {
     console.log("connection opened to", url, ": ", e);
+    console.log("subscribing with", subscriptions);
+    g_ws.send(JSON.stringify(subscriptions));
   });
   g_ws.addEventListener("message", g_messageCallback);
+}
+
+function updateSubscriptions(newSubscriptions) {
+  subscriptions = newSubscriptions;
+  if (g_ws && g_ws.readyState === WebSocket.OPEN) {
+    console.log("updating subscriptions with", subscriptions);
+    g_ws.send(JSON.stringify(subscriptions));
+  }
 }
 
 function drawWebsocketError(id) {

--- a/tools/websocket/www/netinfo.html
+++ b/tools/websocket/www/netinfo.html
@@ -199,6 +199,7 @@
 
   window.onload = (event) => {
     runUnitTests()
+    updateSubscriptions({ rpc: true })
     initWebsocketPicker("websockets.json", "websocket-picker", handleWebsocketMessage, handleWebsocketReset)
   };
 

--- a/tools/websocket/www/p2p-circle.html
+++ b/tools/websocket/www/p2p-circle.html
@@ -356,6 +356,7 @@
 
   window.onload = (event) => {
     runUnitTests()
+    updateSubscriptions({ ebpf: { messages: true, connections: true } })
     initWebsocketPicker("websockets.json", "websocket-picker", processWebsocketMessage, handleWebsocketReset)
   };
 

--- a/tools/websocket/www/peers.html
+++ b/tools/websocket/www/peers.html
@@ -427,6 +427,7 @@
   window.onload = (event) => {
     cleanUpClosedPeers()
     runUnitTests()
+    updateSubscriptions({ ebpf: { messages: true, connections: true } })
     initWebsocketPicker("websockets.json", "websocket-picker", processWebsocketMessage, handleWebsocketReset)
   };
 

--- a/tools/websocket/www/pingpong.html
+++ b/tools/websocket/www/pingpong.html
@@ -236,6 +236,7 @@
   window.onload = (event) => {
     cleanUpClosedPeers()
     runUnitTests()
+    updateSubscriptions({ ebpf: { messages: true, connections: true } })
     initWebsocketPicker("websockets.json", "websocket-picker", processWebsocketMessage, handleWebsocketReset)
   };
 

--- a/tools/websocket/www/txrelay.html
+++ b/tools/websocket/www/txrelay.html
@@ -321,6 +321,7 @@
   window.onload = (event) => {
     cleanUpClosedPeers()
     runUnitTests()
+    updateSubscriptions({ ebpf: { messages: true, connections: true } })
     initWebsocketPicker("websockets.json", "websocket-picker", processWebsocketMessage, handleWebsocketReset)
   };
 


### PR DESCRIPTION
Use port 0 (OS-assigned) for the websocket TCP listener in integration tests instead of manually picking random ephemeral ports. This eliminates the race condition that can cause intermittent "Address already in use" failures.

The `run()` function now accepts an optional `oneshot::Sender` that reports the actual bound address back to the caller. This also replaces the previous 1-second sleep with a proper synchronization barrier, making tests both faster and more reliable.