### PR TITLE
fix(log): filter log level markers and use state predicate guards

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.c linguist-documentation
+*.h linguist-documentation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,34 @@ jobs:
     - name: Run tests
       run: nix-shell --pure --command "cargo test --all-features"
 
+  nix-test-detect-intermittent-failures:
+    runs-on: ubuntu-latest
+    needs: nix-test
+    steps:
+    - uses: actions/checkout@v6
+    - uses: ./.github/actions/setup-nix-action
+    # use separate steps for iterations here to easily see on GHA the time it took
+    - name: Iteration 0
+      run: nix-shell --pure --command "cargo test --all-features"
+    - name: Iteration 1
+      run: nix-shell --pure --command "cargo test --all-features"
+    - name: Iteration 2
+      run: nix-shell --pure --command "cargo test --all-features"
+    - name: Iteration 3
+      run: nix-shell --pure --command "cargo test --all-features"
+    - name: Iteration 4
+      run: nix-shell --pure --command "cargo test --all-features"
+    - name: Iteration 5
+      run: nix-shell --pure --command "cargo test --all-features"
+    - name: Iteration 6
+      run: nix-shell --pure --command "cargo test --all-features"
+    - name: Iteration 7
+      run: nix-shell --pure --command "cargo test --all-features"
+    - name: Iteration 8
+      run: nix-shell --pure --command "cargo test --all-features"
+    - name: Iteration 9
+      run: nix-shell --pure --command "cargo test --all-features"
+
   nix-format:
     runs-on: ubuntu-latest
     steps:
@@ -81,6 +109,36 @@ jobs:
     - name: Install integration test dependecies
       run: sudo apt-get install -y nats-server
     - name: Run tests and integration tests
+      run: NATS_SERVER_BINARY=$(which nats-server) cargo test --all-features
+
+  ubuntu-test-detect-intermittent-failures:
+    runs-on: ubuntu-latest
+    needs: ubuntu-test
+    steps:
+    - uses: actions/checkout@v6
+    - uses: ./.github/actions/setup-ubuntu-action
+    - name: Install integration test dependecies
+      run: sudo apt-get install -y nats-server
+    # use separate steps for iterations here to easily see on GHA the time it took
+    - name: Iteration 0
+      run: NATS_SERVER_BINARY=$(which nats-server) cargo test --all-features
+    - name: Iteration 1
+      run: NATS_SERVER_BINARY=$(which nats-server) cargo test --all-features
+    - name: Iteration 2
+      run: NATS_SERVER_BINARY=$(which nats-server) cargo test --all-features
+    - name: Iteration 3
+      run: NATS_SERVER_BINARY=$(which nats-server) cargo test --all-features
+    - name: Iteration 4
+      run: NATS_SERVER_BINARY=$(which nats-server) cargo test --all-features
+    - name: Iteration 5
+      run: NATS_SERVER_BINARY=$(which nats-server) cargo test --all-features
+    - name: Iteration 6
+      run: NATS_SERVER_BINARY=$(which nats-server) cargo test --all-features
+    - name: Iteration 7
+      run: NATS_SERVER_BINARY=$(which nats-server) cargo test --all-features
+    - name: Iteration 8
+      run: NATS_SERVER_BINARY=$(which nats-server) cargo test --all-features
+    - name: Iteration 9
       run: NATS_SERVER_BINARY=$(which nats-server) cargo test --all-features
 
   ubuntu-docs-tools:

--- a/README.md
+++ b/README.md
@@ -24,31 +24,31 @@ selected P2P measurements as events into a NATS pub-sub queue.
 
 The `log-extractor` publishes them parsed `debug.log` log messages as events to NATS.
 
-The tools are written in Python or Rust (or any other language that supports NATS
-and protobuf). They subscribe to the NATS server. For example, the `logger` tool
-simply prints out all messages that it receives, the `metrics` tool produces prometheus
-metrics, and the `addr-connectivity` tool tests received addresses if they are reachable.
-Python tools can make use of the `protobuf/python-types` to deserialize the Protobuf
-messages while Rust tools can use the types from the `shared` Rust module.
+The tools are written in Rust (or any other language that supports NATS 
+and protobuf). They subscribe to the NATS server. For example, the `logger` tool 
+simply prints out all messages that it receives, the `metrics` tool produces prometheus 
+metrics, and the `connectivity-check` tool tests received addresses if they are reachable. 
+Rust tools can use the types from the `shared` Rust module to deserialize the Protobuf 
+messages. For other languages, types can be generated directly from the Protobuf definitions.
 
 ```
                                            protobuf
                                            messages
-┌─────────────┐    ┌───────────────┐     ┌─────────┐      ┌────────────────────┐
-│             ├────► ebpf-extractor├─────┤         │      │                    │
-│             │    └───────────────┘     │         │      │ Tools              │
-│             │                          │         │      │                    │
-│             │    ┌───────────────┐     │         ├──────┼──►logger           │
-│             ├────► rpc-extractor │─────┤         │      │                    │
-│   Bitcoin   │    └───────────────┘     │ NATS.io ├──────┼──►metrics          │
-│             │                          │         │      │                    │
-│     Node    │    ┌───────────────┐     │ PUB-SUB ├──────┼──►websocket        │
-│             ├────► p2p-extractor │─────┤         │      │                    │
-│             │    └───────────────┘     │         ├──────┼──►addr-connectivty │
-│             │                          │         │      │                    │
-│             │    ┌───────────────┐     │         │      │   ...              │
-│             ├────► log-extractor │─────┤         │      │                    │
-└─────────────┘    └───────────────┘     └─────────┘      └────────────────────┘
+┌─────────────┐    ┌───────────────┐     ┌─────────┐      ┌──────────────────────┐
+│             ├────► ebpf-extractor├─────┤         │      │                      │
+│             │    └───────────────┘     │         │      │ Tools                │
+│             │                          │         │      │                      │
+│             │    ┌───────────────┐     │         ├──────┼──►logger             │
+│             ├────► rpc-extractor │─────┤         │      │                      │
+│   Bitcoin   │    └───────────────┘     │ NATS.io ├──────┼──►metrics            │
+│             │                          │         │      │                      │
+│     Node    │    ┌───────────────┐     │ PUB-SUB ├──────┼──►websocket          │
+│             ├────► p2p-extractor │─────┤         │      │                      │
+│             │    └───────────────┘     │         ├──────┼──►connectivity-check │
+│             │                          │         │      │                      │
+│             │    ┌───────────────┐     │         │      │   ...                │
+│             ├────► log-extractor │─────┤         │      │                      │
+└─────────────┘    └───────────────┘     └─────────┘      └──────────────────────┘
 
  (edit on asciiflow.com)
 ```
@@ -81,7 +81,6 @@ tool uses the events differently:
 | metrics               | produces prometheus metrics from events.                                         | `rust`       | [tools/metrics/](tools/metrics)         |
 | websocket             | publishes events into a websocket as JSON                                        | `rust`       | [tools/websocket/](tools/websocket)     |
 | connectivity-check    | connects to IP addresses received via `addr(v2)` messages and records the result | `rust`       | [tools/connectivity-check/](tools/connectivity-check)    |
-| record-getblocktxn-py | records sent and received `getblocktxn` messages                                 | `python`     | [tools/record-getblocktxn-py/](tools/record-getblocktxn-py) |
 
 ## Real-world usage
 

--- a/extractors/log/tests/integration.rs
+++ b/extractors/log/tests/integration.rs
@@ -349,9 +349,10 @@ async fn test_integration_logextractor_block_checked() {
         |event| {
             match event {
                 PeerObserverEvent::LogExtractor(r) => {
-                    if let Some(log::LogEvent::BlockCheckedLog(block_checked)) = r.log_event {
+                    if let Some(log::LogEvent::BlockCheckedLog(block_checked)) = r.log_event
+                        && block_checked.state == "Valid"
+                    {
                         assert!(!block_checked.block_hash.is_empty());
-                        assert_eq!(block_checked.state, "Valid");
                         info!("BlockCheckedLog event {}", block_checked);
                         return true;
                     }
@@ -400,8 +401,8 @@ async fn test_integration_logextractor_mutated_block_bad_witness_nonce_size() {
                 PeerObserverEvent::LogExtractor(r) => {
                     if let Some(ref e) = r.log_event
                         && let log::LogEvent::BlockCheckedLog(block_checked) = e
+                        && block_checked.state == "bad-witness-nonce-size"
                     {
-                        assert_eq!(block_checked.state, "bad-witness-nonce-size");
                         assert_eq!(
                             block_checked.debug_message,
                             "CheckWitnessMalleation : invalid witness reserved value size"
@@ -455,8 +456,8 @@ async fn test_integration_logextractor_mutated_block_bad_txnmrklroot() {
                 PeerObserverEvent::LogExtractor(l) => {
                     if let Some(ref e) = l.log_event
                         && let log::LogEvent::BlockCheckedLog(block_checked) = e
+                        && block_checked.state == "bad-txnmrklroot"
                     {
-                        assert_eq!(block_checked.state, "bad-txnmrklroot");
                         assert_eq!(block_checked.debug_message, "hashMerkleRoot mismatch");
                         info!("BlockCheckedLog event {}", block_checked);
                         return true;

--- a/shared/src/log_matchers.rs
+++ b/shared/src/log_matchers.rs
@@ -172,6 +172,17 @@ struct CommonLogData {
     pub message: String,
 }
 
+/// Returns `true` if `s` is a standalone Bitcoin Core log level bracket token.
+///
+/// Only `LogError()` and `LogWarning()` produce standalone bracket tokens
+/// (`[error]` and `[warning]`). Other Bitcoin Core log levels never appear as
+/// standalone brackets: `LogInfo()` emits no bracket at all, and
+/// `LogDebug()`/`LogTrace()` require a category argument so they produce
+/// `[category]` or `[category:trace]`, never standalone `[debug]` or `[trace]`.
+fn is_standalone_log_level(s: &str) -> bool {
+    matches!(s.to_lowercase().as_str(), "error" | "warning")
+}
+
 fn parse_common_log_data(line: &str) -> CommonLogData {
     let caps = LOG_LINE_REGEX.captures(line);
     if caps.is_none() {
@@ -200,6 +211,11 @@ fn parse_common_log_data(line: &str) -> CommonLogData {
         .captures_iter(metadata)
         .map(|cap| cap[1].to_string())
         .collect();
+
+    // Filter out log level markers. Bitcoin Core uses LogError(), LogWarning(),
+    // etc. which emit [error], [warning], etc. These are log LEVELS, not
+    // threadnames or debug categories.
+    metadata_items.retain(|item| !is_standalone_log_level(item));
 
     // if exists, category is usually the last metadata item
     let mut category = LogDebugCategory::Unknown;
@@ -449,5 +465,72 @@ mod tests {
             return;
         }
         panic!("Expected BlockCheckedLog event");
+    }
+
+    #[test]
+    fn test_log_matcher_error_level_not_treated_as_threadname() {
+        // Bitcoin Core LogError() emits [error] as a log level, not a threadname
+        let log = "2025-10-02T02:31:14Z [error] AcceptBlock: bad-witness-nonce-size, CheckWitnessMalleation : invalid witness reserved value size";
+        let log_event = parse_log_event(log);
+
+        assert_eq!(log_event.category, LogDebugCategory::Unknown as i32);
+        assert_eq!(log_event.threadname, "");
+
+        if let Some(LogEvent::UnknownLogMessage(unknown_log)) = log_event.log_event {
+            assert_eq!(
+                unknown_log.raw_message,
+                "AcceptBlock: bad-witness-nonce-size, CheckWitnessMalleation : invalid witness reserved value size"
+            );
+            return;
+        }
+        panic!("Expected UnknownLogMessage event");
+    }
+
+    #[test]
+    fn test_log_matcher_error_level_with_threadname() {
+        // [threadname] [error] message - error should be filtered, threadname preserved
+        let log = "2025-10-02T02:31:14Z [msghand] [error] some error message";
+        let log_event = parse_log_event(log);
+
+        assert_eq!(log_event.threadname, "msghand");
+        assert_eq!(log_event.category, LogDebugCategory::Unknown as i32);
+
+        if let Some(LogEvent::UnknownLogMessage(unknown_log)) = log_event.log_event {
+            assert_eq!(unknown_log.raw_message, "some error message");
+            return;
+        }
+        panic!("Expected UnknownLogMessage event");
+    }
+
+    #[test]
+    fn test_log_matcher_warning_level_filtered() {
+        let log = "2025-10-02T02:31:14Z [warning] some warning message";
+        let log_event = parse_log_event(log);
+
+        assert_eq!(log_event.threadname, "");
+        assert_eq!(log_event.category, LogDebugCategory::Unknown as i32);
+
+        if let Some(LogEvent::UnknownLogMessage(unknown_log)) = log_event.log_event {
+            assert_eq!(unknown_log.raw_message, "some warning message");
+            return;
+        }
+        panic!("Expected UnknownLogMessage event");
+    }
+
+    #[test]
+    fn test_is_standalone_log_level() {
+        assert!(is_standalone_log_level("error"));
+        assert!(is_standalone_log_level("Error"));
+        assert!(is_standalone_log_level("ERROR"));
+        assert!(is_standalone_log_level("warning"));
+        assert!(is_standalone_log_level("Warning"));
+        // info/debug/trace are NOT standalone bracket tokens in Bitcoin Core
+        assert!(!is_standalone_log_level("info"));
+        assert!(!is_standalone_log_level("debug"));
+        assert!(!is_standalone_log_level("trace"));
+        assert!(!is_standalone_log_level("net"));
+        assert!(!is_standalone_log_level("validation"));
+        assert!(!is_standalone_log_level("msghand"));
+        assert!(!is_standalone_log_level("dnsseed"));
     }
 }


### PR DESCRIPTION
Bitcoin Core's LogError()/LogWarning() emit lines like `[error] AcceptBlock: ...` where `[error]` is a severity level, not a threadname or debug category. The log parser was treating these as threadnames, causing lines to be parsed as UnknownLogMessage instead of their correct event type (e.g. BlockCheckedLog).

Add is_log_level() filter to strip known log levels (error, warning, info, debug, trace) from metadata items before category/threadname extraction.

Also move block_checked.state assertions into if-let predicate guards in integration tests (same pattern as PR #354) so that events with non-matching state are skipped rather than causing panics from event ordering races.

Somewhat addresses #366.. there are sill issues related to intermittent failure of some log lines making it through the `tail -f > pipe` mechanism...