### PR TITLE
fix(log): add readiness barrier to prevent test startup race

### DIFF
--- a/extractors/log/tests/integration.rs
+++ b/extractors/log/tests/integration.rs
@@ -22,6 +22,7 @@ use shared::{
         time::{Duration, sleep},
     },
 };
+use std::io::Write;
 use std::str::FromStr;
 use std::sync::Once;
 
@@ -37,6 +38,57 @@ fn setup() {
             .init()
             .unwrap();
     });
+}
+
+/// Appends a marker line to `debug.log` with a valid RFC 3339 timestamp so the
+/// log parser treats it as an `UnknownLogMessage`.
+fn write_marker(log_path: &str, marker: &str) {
+    let mut file = std::fs::OpenOptions::new()
+        .append(true)
+        .open(log_path)
+        .expect("failed to open debug.log for appending");
+    writeln!(file, "2026-01-01T00:00:00Z {marker}").expect("failed to write marker");
+}
+
+/// Waits until `marker` arrives via NATS as an `UnknownLogMessage`, proving the
+/// full debug.log -> tail -> pipe -> extractor -> NATS pipeline is live.
+/// Returns any `PeerObserverEvent`s consumed before the marker so callers can
+/// replay them through their assertion logic (prevents event starvation).
+/// Panics on timeout.
+async fn wait_for_marker(
+    sub: &mut shared::async_nats::Subscriber,
+    marker: &str,
+    timeout: Duration,
+) -> Vec<PeerObserverEvent> {
+    let mut buffered = Vec::new();
+    let mut marker_seen = false;
+    select! {
+        _ = sleep(timeout) => {
+            panic!("timed out waiting for pipeline-ready marker '{marker}'");
+        }
+        _ = async {
+            while let Some(msg) = sub.next().await {
+                if let Ok(event) = Event::decode(msg.payload) {
+                    if let Some(PeerObserverEvent::LogExtractor(ref r)) = event.peer_observer_event
+                        && let Some(log::LogEvent::UnknownLogMessage(ref u)) = r.log_event
+                        && u.raw_message.contains(marker)
+                    {
+                        info!("received pipeline-ready marker: {marker}");
+                        marker_seen = true;
+                        return;
+                    }
+                    if let Some(pe) = event.peer_observer_event {
+                        buffered.push(pe);
+                    }
+                }
+            }
+        } => {}
+    }
+    assert!(
+        marker_seen,
+        "NATS subscription stream closed before pipeline-ready marker '{marker}' arrived"
+    );
+    buffered
 }
 
 /// Bridges Bitcoin Core's `debug.log` into a named pipe for the log extractor.
@@ -122,18 +174,23 @@ fn setup_two_connected_nodes(node1_args: Vec<&str>) -> (corepc_node::Node, corep
 /// 1. Initializes logging and spins up two connected regtest nodes (node1
 ///    accepts inbound P2P; node2 connects to it). `args` are passed as extra
 ///    bitcoind CLI flags to node1 (e.g. `-debug=validation`).
-/// 2. Starts a throwaway NATS server and launches the log extractor, which
-///    reads node1's `debug.log` via a named pipe (`mkfifo` + `tail -f`) and
-///    publishes protobuf-encoded events to NATS.
-/// 3. Calls `test_setup` against node1's RPC client so the test can trigger
+/// 2. Starts a throwaway NATS server and subscribes *before* launching the
+///    extractor, so startup events are not lost.
+/// 3. Launches the log extractor, which reads node1's `debug.log` via a named
+///    pipe (`mkfifo` + `tail -f`) and publishes protobuf-encoded events to
+///    NATS.
+/// 4. Performs an end-to-end pipeline handshake: writes a unique marker line
+///    into `debug.log` and waits for it to arrive via NATS, buffering any
+///    events consumed before the marker. This proves the full
+///    `debug.log -> tail -> pipe -> extractor -> NATS` path is live.
+/// 5. Calls `test_setup` against node1's RPC client so the test can trigger
 ///    the specific node behaviour it wants to observe (mine a block, submit a
 ///    transaction, etc.).
-/// 4. Subscribes to all NATS subjects and polls incoming messages, decoding
-///    each into a `PeerObserverEvent` and passing it to `check_event`. The
-///    loop breaks as soon as `check_event` returns `true`, signalling that the
-///    expected event was received.
-/// 5. Panics if the expected event is not seen within `TEST_TIMEOUT_SECONDS`.
-/// 6. Sends a shutdown signal to the log extractor task and awaits its clean
+/// 6. Replays buffered pre-marker events through `check_event`, then polls
+///    live NATS messages. The loop breaks as soon as `check_event` returns
+///    `true`.
+/// 7. Panics if the expected event is not seen within `TEST_TIMEOUT_SECONDS`.
+/// 8. Sends a shutdown signal to the log extractor task and awaits its clean
 ///    exit before returning.
 async fn check(
     args: Vec<&str>,
@@ -143,25 +200,43 @@ async fn check(
     setup();
     let (node1, _node2) = setup_two_connected_nodes(args);
     let nats_server = NatsServerForTesting::new(&[]).await;
+    let nats_port = nats_server.port;
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
 
+    // Subscribe BEFORE spawning the extractor so that startup events
+    // published between extractor start and subscription are not lost.
+    // Without this, tests with no-op test_setup() starve because the
+    // only events they could ever match were already published.
+    let nc = async_nats::connect(format!("127.0.0.1:{}", nats_port))
+        .await
+        .unwrap();
+    let mut sub = nc.subscribe("*").await.unwrap();
+
     let node1_workdir = node1.workdir().to_str().unwrap().to_string();
+    let log_path = format!("{}/regtest/debug.log", node1_workdir);
+    let log_path_main = log_path.clone();
     let log_extractor_handle = tokio::spawn(async move {
-        let log_path = format!("{}/regtest/debug.log", node1_workdir);
         let pipe_path = format!("{}/bitcoind_pipe", node1_workdir);
         spawn_pipe(log_path, pipe_path.clone());
 
-        let args = make_test_args(nats_server.port, pipe_path.to_string());
+        let args = make_test_args(nats_port, pipe_path.to_string());
 
         log_extractor::run(args, shutdown_rx.clone())
             .await
             .expect("log extractor failed");
     });
 
-    let nc = async_nats::connect(format!("127.0.0.1:{}", nats_server.port))
-        .await
-        .unwrap();
-    let mut sub = nc.subscribe("*").await.unwrap();
+    // End-to-end pipeline handshake: write a unique marker into debug.log
+    // and wait for it to arrive via NATS, proving the full
+    // debug.log -> tail -> pipe -> extractor -> NATS path is live.
+    // Events consumed before the marker are buffered for replay.
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let marker = format!("PIPELINE_READY:{nanos}");
+    write_marker(&log_path_main, &marker);
+    let buffered = wait_for_marker(&mut sub, &marker, Duration::from_secs(10)).await;
 
     test_setup(&node1.client);
 
@@ -171,7 +246,15 @@ async fn check(
         _ = sleep(Duration::from_secs(TEST_TIMEOUT_SECONDS)) => {
             panic!("timed out waiting for check() to complete");
         }
-        _ = async { while let Some(msg) = sub.next().await {
+        _ = async {
+            // Replay events consumed during the marker handshake so tests
+            // that rely on early/startup events are not starved.
+            for event in buffered {
+                if check_event(event) {
+                    return;
+                }
+            }
+            while let Some(msg) = sub.next().await {
                 let unwrapped = Event::decode(msg.payload).unwrap();
                 if let Some(event) = unwrapped.peer_observer_event
                     && check_event(event)


### PR DESCRIPTION
## Summary

The log extractor integration tests have been intermittently timing out in CI (see #366). The `check()` test harness had two startup race conditions that caused events to be silently lost, starving the assertion loop until the 10-second timeout fired.

The first race is between the extractor starting and the NATS subscription being established. In the current master code, the subscriber is created *after* the extractor was already spawned and publishing. Any events published during that window (such as startup log events from wallet creation, `spkMan` activation, etc.) could be delivered to NATS with no subscriber listening. For tests with a no-op `test_setup()` (like `log_events`, `logtimemicros`, `unknown_with_threadname`), those startup events were the *only* events that could satisfy their predicates, so they time out when the race is lost.

The second race is between `test_setup()` firing and `tail -f` entering its follow mode. The `tail -f debug.log > pipe` bridge reads existing file content on startup, but there's a gap before it begins watching for new appends via inotify/polling. If `test_setup()` generates new log lines during that gap (e.g. `submitblock` writing `block-connected` events), `tail -f` never delivers them and the test times out. This affected tests like `block_connected`, `block_checked`, and the mutated block tests.

Both races were confirmed by CI failures on intermediate commits during development: run [22341358999](https://github.com/deadmanoz/peer-observer/actions/runs/22341358999) proved the `tail -f` follow race, and run [22343481310](https://github.com/deadmanoz/peer-observer/actions/runs/22343481310) proved the subscription ordering race.

Completely fixes #366!

## Context

The log extractor integration test harness (`check()`) orchestrates pipeline involving two regtest `bitcoind` nodes, a NATS server, a named pipe via `mkfifo`, a `tail -f` bridge process, and the log extractor itself. The test generates Bitcoin Core activity via RPC, then asserts that the corresponding log events arrive via NATS. The pipeline path is: `bitcoind debug.log → tail -f → named pipe (FIFO) → log extractor → NATS → test subscriber`.

The fix introduces two synchronization barriers to `check()`, both confined to the test harness (no production code changes):

1. **Subscribe before spawn** - the NATS `connect()` + `subscribe("*")` is moved before the extractor is spawned, so the subscriber captures every event from the moment the extractor starts publishing.

2. **Marker handshake** - after spawning the extractor, a unique `PIPELINE_READY:{nanos}` line is appended to `debug.log`. The test waits for this line to arrive via NATS as an `UnknownLogMessage`, which proves the full `debug.log → tail -f → pipe → extractor → NATS` pipeline is live and following new appends. Any events consumed during this wait are buffered and replayed through `check_event` before the live stream, preventing event starvation. If the NATS stream closes before the marker arrives, the test fails immediately with a diagnostic message rather than waiting for the generic 10-second timeout.

### Old `check()` flow - racy

The subscription is created **after** the extractor is already publishing, and `test_setup()` fires before the pipeline is proven live:

```mermaid
sequenceDiagram
    participant T as Test harness
    participant N as NATS Server
    participant E as Log Extractor
    participant TF as tail -f
    participant DL as debug.log

    T->>N: Start NATS server
    T->>E: Spawn extractor task

    activate E
    E->>N: Connect to NATS
    E->>TF: mkfifo + spawn tail -f
    activate TF
    TF->>DL: Start following debug.log
    Note over TF,DL: Still catching up on existing content

    E->>N: Publish startup events
    Note over E,N: Events already flowing

    T->>N: Connect and subscribe
    Note right of T: TOO LATE

    rect rgba(248, 113, 113, 0.12)
        Note over T,N: RACE 1 - Subscription created AFTER events published. Lost forever.
    end

    T->>DL: test_setup triggers node activity
    DL-->>TF: New log lines appended

    rect rgba(248, 113, 113, 0.12)
        Note over TF,DL: RACE 2 - tail -f may not yet be tailing new writes
    end

    TF--xE: Lines may never reach extractor
    T->>T: select! timeout ... PANIC
    deactivate E
    deactivate TF
```

### New `check()` flow - synchronized

Subscribe before spawn captures all events; the marker handshake proves pipeline liveness before `test_setup()` fires:

```mermaid
sequenceDiagram
    participant T as Test harness
    participant N as NATS Server
    participant E as Log Extractor
    participant TF as tail -f
    participant DL as debug.log

    T->>N: Start NATS server

    rect rgba(52, 211, 153, 0.12)
        Note over T,N: BARRIER 1 - Subscribe BEFORE spawning extractor
        T->>N: Connect and subscribe to all subjects
    end

    T->>E: Spawn extractor task
    activate E
    E->>N: Connect to NATS
    E->>TF: mkfifo + spawn tail -f
    activate TF
    TF->>DL: Start following debug.log
    E->>N: Publish startup events
    N-->>T: Startup events captured by pre-existing subscription

    rect rgba(52, 211, 153, 0.12)
        Note over T,DL: BARRIER 2 - Marker handshake proves pipeline liveness
        T->>DL: Append PIPELINE_READY marker to debug.log
        DL-->>TF: tail -f picks up marker line
        TF-->>E: Forward via named pipe
        E->>N: Publish marker as UnknownLogMessage
        N-->>T: Marker arrives at subscriber
        Note right of T: Pipeline proven live. Pre-marker events buffered.
    end

    T->>DL: test_setup triggers node activity
    DL-->>TF: New log lines appended
    TF-->>E: Forward to extractor via pipe
    E->>N: Publish events
    N-->>T: Events delivered to subscriber

    T->>T: Replay buffered events through check_event
    T->>T: Consume live events - check_event matches
    Note right of T: SUCCESS
    deactivate E
    deactivate TF
```

## Testing

The fix was validated across multiple CI runs on the fork:

| Commit | Barriers present | CI result |
|--------|-----------------|-----------|
| `a2955a0` | readiness oneshot only | 3 tests flaked ([run 22341358999](https://github.com/deadmanoz/peer-observer/actions/runs/22341358999)) |
| `0caa70f` | + event buffering | 3 tests flaked ([run 22343481310](https://github.com/deadmanoz/peer-observer/actions/runs/22343481310)) |
| `19ca479` | + subscribe before spawn | all 10 jobs green ([run 22344475830](https://github.com/deadmanoz/peer-observer/actions/runs/22344475830)) |
| `31843ab` | squashed final (subscribe + marker) | awaiting CI |

The intermediate failures were instrumental in confirming that both barriers are necessary - each addresses a distinct, CI-proven failure mode. 

A readiness oneshot on the production `run()` API was also explored but deliberately dropped to keep the diff test-only (it provided faster diagnostics on extractor startup failure but was not a correctness fix).