### PR TITLE
fix(rpc-extractor): use OS-assigned port in integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,7 @@ checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 name = "archiver"
 version = "0.1.0"
 dependencies = [
+ "replayer",
  "serde",
  "sha2",
  "shared",
@@ -1664,6 +1665,14 @@ name = "regex-syntax"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
+
+[[package]]
+name = "replayer"
+version = "0.1.0"
+dependencies = [
+ "shared",
+ "zstd",
+]
 
 [[package]]
 name = "ring"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,7 +109,7 @@ dependencies = [
  "regex",
  "rustls-native-certs",
  "rustls-pki-types",
- "rustls-webpki 0.103.10",
+ "rustls-webpki",
  "serde",
  "serde_json",
  "serde_repr",
@@ -218,6 +218,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitcoind"
+version = "0.38.0"
+source = "git+https://github.com/0xb10c/corepc?rev=8798e7f9c240c626dc3aa61adadeaf42f8221e40#8798e7f9c240c626dc3aa61adadeaf42f8221e40"
+dependencies = [
+ "anyhow",
+ "bitcoin_hashes",
+ "bitreq",
+ "corepc-client",
+ "flate2",
+ "log",
+ "serde_json",
+ "tar",
+ "tempfile",
+ "which",
+ "zip",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -231,11 +249,11 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "bitreq"
-version = "0.3.4"
-source = "git+https://github.com/0xb10c/corepc?rev=9e4eb4d7181575ff75f9e0a6997b091bd5023b1d#9e4eb4d7181575ff75f9e0a6997b091bd5023b1d"
+version = "0.3.5"
+source = "git+https://github.com/0xb10c/corepc?rev=8798e7f9c240c626dc3aa61adadeaf42f8221e40#8798e7f9c240c626dc3aa61adadeaf42f8221e40"
 dependencies = [
- "rustls 0.21.12",
- "rustls-webpki 0.101.7",
+ "rustls",
+ "rustls-webpki",
  "serde",
  "serde_json",
  "webpki-roots",
@@ -440,8 +458,8 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "corepc-client"
-version = "0.12.0"
-source = "git+https://github.com/0xb10c/corepc?rev=9e4eb4d7181575ff75f9e0a6997b091bd5023b1d#9e4eb4d7181575ff75f9e0a6997b091bd5023b1d"
+version = "0.13.0"
+source = "git+https://github.com/0xb10c/corepc?rev=8798e7f9c240c626dc3aa61adadeaf42f8221e40#8798e7f9c240c626dc3aa61adadeaf42f8221e40"
 dependencies = [
  "bitcoin",
  "corepc-types",
@@ -452,27 +470,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "corepc-node"
-version = "0.12.0"
-source = "git+https://github.com/0xb10c/corepc?rev=9e4eb4d7181575ff75f9e0a6997b091bd5023b1d#9e4eb4d7181575ff75f9e0a6997b091bd5023b1d"
-dependencies = [
- "anyhow",
- "bitcoin_hashes",
- "bitreq",
- "corepc-client",
- "flate2",
- "log",
- "serde_json",
- "tar",
- "tempfile",
- "which",
- "zip",
-]
-
-[[package]]
 name = "corepc-types"
 version = "0.12.0"
-source = "git+https://github.com/0xb10c/corepc?rev=9e4eb4d7181575ff75f9e0a6997b091bd5023b1d#9e4eb4d7181575ff75f9e0a6997b091bd5023b1d"
+source = "git+https://github.com/0xb10c/corepc?rev=8798e7f9c240c626dc3aa61adadeaf42f8221e40#8798e7f9c240c626dc3aa61adadeaf42f8221e40"
 dependencies = [
  "bitcoin",
  "serde",
@@ -1078,8 +1078,8 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc"
-version = "0.19.0"
-source = "git+https://github.com/0xb10c/corepc?rev=9e4eb4d7181575ff75f9e0a6997b091bd5023b1d#9e4eb4d7181575ff75f9e0a6997b091bd5023b1d"
+version = "0.20.0"
+source = "git+https://github.com/0xb10c/corepc?rev=8798e7f9c240c626dc3aa61adadeaf42f8221e40#8798e7f9c240c626dc3aa61adadeaf42f8221e40"
 dependencies = [
  "base64 0.22.1",
  "bitreq",
@@ -1691,24 +1691,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
-name = "rustls"
-version = "0.23.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "once_cell",
+ "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.8",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -1736,31 +1726,11 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.7"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
- "untrusted",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.102.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
-dependencies = [
- "ring",
- "rustls-pki-types",
- "untrusted",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.103.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
-dependencies = [
  "rustls-pki-types",
  "untrusted",
 ]
@@ -1791,16 +1761,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "secp256k1"
@@ -1934,9 +1894,9 @@ dependencies = [
  "async-nats",
  "base32",
  "bitcoin",
+ "bitcoind",
  "clap",
  "corepc-client",
- "corepc-node",
  "futures",
  "hex",
  "lazy_static",
@@ -2196,7 +2156,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls 0.23.23",
+ "rustls",
  "tokio",
 ]
 
@@ -2435,9 +2395,12 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.25.4"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "websocket"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,6 +96,7 @@ dependencies = [
  "sha2",
  "shared",
  "toml",
+ "zstd",
 ]
 
 [[package]]
@@ -357,6 +358,8 @@ version = "1.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -1075,6 +1078,16 @@ name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.3",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -2911,4 +2924,32 @@ dependencies = [
  "crc32fast",
  "crossbeam-utils",
  "flate2",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,7 @@ dependencies = [
  "replayer",
  "sha2",
  "shared",
+ "time",
  "toml",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,7 +92,10 @@ checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 name = "archiver"
 version = "0.1.0"
 dependencies = [
+ "serde",
+ "sha2",
  "shared",
+ "toml",
 ]
 
 [[package]]
@@ -831,9 +834,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "heck"
@@ -1044,9 +1047,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1875,10 +1878,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2203,6 +2226,47 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tracing"
@@ -2722,6 +2786,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
+name = "archiver"
+version = "0.1.0"
+dependencies = [
+ "shared",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "alerts"
+version = "0.1.0"
+dependencies = [
+ "shared",
+]
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,7 +93,6 @@ name = "archiver"
 version = "0.1.0"
 dependencies = [
  "replayer",
- "serde",
  "sha2",
  "shared",
  "toml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,6 @@ dependencies = [
  "sha2",
  "shared",
  "toml",
- "zstd",
 ]
 
 [[package]]
@@ -1670,7 +1669,6 @@ name = "replayer"
 version = "0.1.0"
 dependencies = [
  "shared",
- "zstd",
 ]
 
 [[package]]
@@ -1961,6 +1959,7 @@ dependencies = [
  "simple_logger",
  "time",
  "tokio",
+ "zstd",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,5 @@ members = [
   "tools/metrics",
   "tools/connectivity-check",
   "tools/archiver",
+  "tools/replayer",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,5 @@ members = [
   "tools/websocket",
   "tools/metrics",
   "tools/connectivity-check",
+  "tools/archiver",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,5 @@ members = [
   "tools/connectivity-check",
   "tools/archiver",
   "tools/replayer",
+  "tools/alerts",
 ]

--- a/extractors/log/tests/integration.rs
+++ b/extractors/log/tests/integration.rs
@@ -5,7 +5,7 @@ use log_extractor::Args;
 use shared::{
     async_nats,
     bitcoin::{Block, consensus::Decodable, hashes::Hash, hex::FromHex},
-    corepc_node,
+    bitcoind,
     futures::StreamExt,
     log::{Level, LevelFilter, info},
     nats_util::NatsArgs,
@@ -128,19 +128,19 @@ fn make_test_args(nats_port: u16, bitcoind_pipe: String) -> Args {
 /// Starts a regtest `bitcoind` node with the given configuration.
 ///
 /// The binary is resolved from the `BITCOIND_EXE` environment variable
-/// (via `corepc_node::exe_path`); if unset, a pre-built binary is
+/// (via `bitcoind::exe_path`); if unset, a pre-built binary is
 /// downloaded automatically.
-fn setup_node(conf: corepc_node::Conf) -> corepc_node::Node {
+fn setup_node(conf: bitcoind::Conf) -> bitcoind::BitcoinD {
     info!("env BITCOIND_EXE={:?}", std::env::var("BITCOIND_EXE"));
-    info!("exe_path={:?}", corepc_node::exe_path());
+    info!("exe_path={:?}", bitcoind::exe_path());
 
-    if let Ok(exe_path) = corepc_node::exe_path() {
+    if let Ok(exe_path) = bitcoind::exe_path() {
         info!("Using bitcoind at '{}'", exe_path);
-        return corepc_node::Node::with_conf(exe_path, &conf).unwrap();
+        return bitcoind::BitcoinD::with_conf(exe_path, &conf).unwrap();
     }
 
     info!("Trying to download a bitcoind..");
-    corepc_node::Node::from_downloaded_with_conf(&conf).unwrap()
+    bitcoind::BitcoinD::from_downloaded_with_conf(&conf).unwrap()
 }
 
 /// Creates a two-node regtest topology:
@@ -149,10 +149,10 @@ fn setup_node(conf: corepc_node::Conf) -> corepc_node::Node {
 ///
 /// `node1_args` are appended as extra `bitcoind` CLI flags (e.g. `-debug=validation`) so tests
 /// can enable the specific logging needed to trigger the events they want to observe.
-fn setup_two_connected_nodes(node1_args: Vec<&str>) -> (corepc_node::Node, corepc_node::Node) {
+fn setup_two_connected_nodes(node1_args: Vec<&str>) -> (bitcoind::BitcoinD, bitcoind::BitcoinD) {
     // node1 listens for p2p connections
-    let mut node1_conf = corepc_node::Conf::default();
-    node1_conf.p2p = corepc_node::P2P::Yes;
+    let mut node1_conf = bitcoind::Conf::default();
+    node1_conf.p2p = bitcoind::P2P::Yes;
     for arg in node1_args {
         info!("Running node1 with arg: {}", arg);
         node1_conf.args.push(arg);
@@ -160,7 +160,7 @@ fn setup_two_connected_nodes(node1_args: Vec<&str>) -> (corepc_node::Node, corep
     let node1 = setup_node(node1_conf);
 
     // node2 connects to node1
-    let mut node2_conf = corepc_node::Conf::default();
+    let mut node2_conf = bitcoind::Conf::default();
     node2_conf.p2p = node1.p2p_connect(true).unwrap();
     let node2 = setup_node(node2_conf);
 
@@ -193,7 +193,7 @@ fn setup_two_connected_nodes(node1_args: Vec<&str>) -> (corepc_node::Node, corep
 ///    exit before returning.
 async fn check(
     args: Vec<&str>,
-    test_setup: fn(&corepc_node::Client),
+    test_setup: fn(&bitcoind::Client),
     check_event: fn(PeerObserverEvent) -> bool,
 ) {
     setup();

--- a/extractors/p2p/tests/integration.rs
+++ b/extractors/p2p/tests/integration.rs
@@ -4,7 +4,7 @@
 use shared::{
     async_nats,
     bitcoin::{self, Amount},
-    corepc_node::{self},
+    bitcoind::{self},
     futures::StreamExt,
     log::{self, info},
     nats_util::NatsArgs,
@@ -72,21 +72,21 @@ fn make_test_args(
     )
 }
 
-fn setup_node(conf: corepc_node::Conf) -> corepc_node::Node {
+fn setup_node(conf: bitcoind::Conf) -> bitcoind::BitcoinD {
     info!("env BITCOIND_EXE={:?}", std::env::var("BITCOIND_EXE"));
-    info!("exe_path={:?}", corepc_node::exe_path());
+    info!("exe_path={:?}", bitcoind::exe_path());
 
-    if let Ok(exe_path) = corepc_node::exe_path() {
+    if let Ok(exe_path) = bitcoind::exe_path() {
         info!("Using bitcoind at '{}'", exe_path);
-        return corepc_node::Node::with_conf(exe_path, &conf).unwrap();
+        return bitcoind::BitcoinD::with_conf(exe_path, &conf).unwrap();
     }
 
     info!("Trying to download a bitcoind..");
-    corepc_node::Node::from_downloaded_with_conf(&conf).unwrap()
+    bitcoind::BitcoinD::from_downloaded_with_conf(&conf).unwrap()
 }
 
-fn configure_node() -> corepc_node::Node {
-    let mut node_conf = corepc_node::Conf::default();
+fn configure_node() -> bitcoind::BitcoinD {
+    let mut node_conf = bitcoind::Conf::default();
     node_conf.args = vec![
         "-regtest",
         "-debug=net",
@@ -100,7 +100,7 @@ fn configure_node() -> corepc_node::Node {
     // enabling this is useful for debugging, but enabling this by default will
     // be quite spammy.
     node_conf.view_stdout = false;
-    node_conf.p2p = corepc_node::P2P::Yes;
+    node_conf.p2p = bitcoind::P2P::Yes;
 
     setup_node(node_conf)
 }
@@ -110,7 +110,7 @@ async fn check(
     disable_addrv2: bool,
     disable_invs: bool,
     disable_feefilter: bool,
-    test_setup: fn(&corepc_node::Node),
+    test_setup: fn(&bitcoind::BitcoinD),
     mut check_expected: impl FnMut(PeerObserverEvent) -> bool,
 ) {
     setup();

--- a/extractors/rpc/src/lib.rs
+++ b/extractors/rpc/src/lib.rs
@@ -10,9 +10,10 @@ use shared::nats_util::{self, NatsArgs};
 use shared::prost::Message;
 use shared::protobuf::event::{Event, event::PeerObserverEvent};
 use shared::protobuf::rpc_extractor::{self, EstimateSmartFee};
-use shared::tokio::sync::watch;
+use shared::tokio::sync::{oneshot, watch};
 use shared::tokio::time::{self, Duration};
 use shared::{async_nats, clap};
+use std::net::SocketAddr;
 
 mod error;
 pub mod metrics;
@@ -172,12 +173,13 @@ impl Args {
     }
 }
 
-pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(), RuntimeError> {
+pub async fn run(
+    args: Args,
+    mut shutdown_rx: watch::Receiver<bool>,
+    bound_addr_tx: Option<oneshot::Sender<SocketAddr>>,
+) -> Result<(), RuntimeError> {
     // Create metrics instance with its own registry
     let metrics = Metrics::new();
-
-    // Start the metric server with our custom registry.
-    shared::metricserver::start(&args.prometheus_address, Some(metrics.registry.clone()))?;
 
     let auth: Auth = match args.rpc_cookie_file {
         Some(path) => Auth::CookieFile(path.into()),
@@ -192,6 +194,19 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
         .connect(&args.nats.address)
         .await?;
     log::info!("Connected to NATS server at {}", &args.nats.address);
+
+    // Start the metric server with our custom registry. This happens after
+    // the RPC client and NATS connection are set up so that any startup
+    // failure surfaces through the readiness barrier in tests (which races
+    // bound_addr_tx against the extractor task handle) instead of leaving
+    // the test to time out. Matches the order used in p2p_extractor::run.
+    let local_addr =
+        shared::metricserver::start(&args.prometheus_address, Some(metrics.registry.clone()))?;
+
+    // Notify the caller of the actual bound address (used in tests with port 0).
+    if let Some(tx) = bound_addr_tx {
+        let _ = tx.send(local_addr);
+    }
 
     let duration_sec = Duration::from_secs(args.query_interval);
     let mut interval = time::interval(duration_sec);

--- a/extractors/rpc/src/lib.rs
+++ b/extractors/rpc/src/lib.rs
@@ -1,9 +1,9 @@
+use shared::bitcoind::mtype::{
+    GetBlockchainInfo, GetChainTxStats, GetNetworkInfo, GetOrphanTxsVerboseTwo,
+};
 use shared::clap::{ArgGroup, Parser};
 use shared::corepc_client::client_sync::Auth;
 use shared::corepc_client::client_sync::v30::{Client, FeeEstimateMode};
-use shared::corepc_node::mtype::{
-    GetBlockchainInfo, GetChainTxStats, GetNetworkInfo, GetOrphanTxsVerboseTwo,
-};
 use shared::log;
 use shared::nats_subjects::Subject;
 use shared::nats_util::{self, NatsArgs};

--- a/extractors/rpc/src/main.rs
+++ b/extractors/rpc/src/main.rs
@@ -12,7 +12,9 @@ async fn main() {
     }
 
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
-    let rpc_handle = tokio::spawn(rpc_extractor::run(args, shutdown_rx));
+    // No bound address notification needed in production (used in tests to
+    // communicate the OS-assigned port back when binding to port 0).
+    let rpc_handle = tokio::spawn(rpc_extractor::run(args, shutdown_rx, None));
 
     tokio::select! {
         _ = signal::ctrl_c() => {

--- a/extractors/rpc/tests/common/mod.rs
+++ b/extractors/rpc/tests/common/mod.rs
@@ -1,5 +1,5 @@
 use shared::{
-    corepc_node,
+    bitcoind,
     log::{self, info},
     nats_util::NatsArgs,
     simple_logger::SimpleLogger,
@@ -148,27 +148,27 @@ pub fn make_test_args(
     )
 }
 
-pub fn setup_node(conf: corepc_node::Conf) -> corepc_node::Node {
+pub fn setup_node(conf: bitcoind::Conf) -> bitcoind::BitcoinD {
     info!("env BITCOIND_EXE={:?}", std::env::var("BITCOIND_EXE"));
-    info!("exe_path={:?}", corepc_node::exe_path());
+    info!("exe_path={:?}", bitcoind::exe_path());
 
-    if let Ok(exe_path) = corepc_node::exe_path() {
+    if let Ok(exe_path) = bitcoind::exe_path() {
         info!("Using bitcoind at '{}'", exe_path);
-        return corepc_node::Node::with_conf(exe_path, &conf).unwrap();
+        return bitcoind::BitcoinD::with_conf(exe_path, &conf).unwrap();
     }
 
     info!("Trying to download a bitcoind..");
-    corepc_node::Node::from_downloaded_with_conf(&conf).unwrap()
+    bitcoind::BitcoinD::from_downloaded_with_conf(&conf).unwrap()
 }
 
-pub fn setup_two_connected_nodes() -> (corepc_node::Node, corepc_node::Node) {
+pub fn setup_two_connected_nodes() -> (bitcoind::BitcoinD, bitcoind::BitcoinD) {
     // node1 listens for p2p connections
-    let mut node1_conf = corepc_node::Conf::default();
-    node1_conf.p2p = corepc_node::P2P::Yes;
+    let mut node1_conf = bitcoind::Conf::default();
+    node1_conf.p2p = bitcoind::P2P::Yes;
     let node1 = setup_node(node1_conf);
 
     // node2 connects to node1
-    let mut node2_conf = corepc_node::Conf::default();
+    let mut node2_conf = bitcoind::Conf::default();
     node2_conf.p2p = node1.p2p_connect(true).unwrap();
     let node2 = setup_node(node2_conf);
 

--- a/extractors/rpc/tests/common/mod.rs
+++ b/extractors/rpc/tests/common/mod.rs
@@ -5,19 +5,9 @@ use shared::{
     simple_logger::SimpleLogger,
 };
 
-use std::net::TcpListener;
 use std::sync::Once;
 
 use rpc_extractor::Args;
-
-/// Get an available port for the metrics server.
-pub fn get_available_port() -> u16 {
-    TcpListener::bind("127.0.0.1:0")
-        .expect("Failed to bind to port 0")
-        .local_addr()
-        .expect("Failed to get local addr")
-        .port()
-}
 
 static INIT: Once = Once::new();
 
@@ -117,7 +107,6 @@ pub fn make_test_args(
     nats_port: u16,
     rpc_url: String,
     cookie_file: String,
-    prometheus_address: String,
     rpcs: EnabledRPCsInTest,
 ) -> Args {
     Args::new(
@@ -132,7 +121,7 @@ pub fn make_test_args(
         cookie_file,
         QUERY_INTERVAL_SECONDS,
         QUERY_INTERVAL_SECONDS, // query_interval_less_frequent, but don't fetch less frequently in tests
-        prometheus_address,
+        "127.0.0.1:0".to_string(),
         !rpcs.getpeerinfo,
         !rpcs.getmempoolinfo,
         !rpcs.uptime,

--- a/extractors/rpc/tests/integration.rs
+++ b/extractors/rpc/tests/integration.rs
@@ -13,7 +13,7 @@ use shared::{
         Amount, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Txid, Witness, absolute,
         consensus, hashes::Hash, hex::DisplayHex, transaction,
     },
-    corepc_node,
+    bitcoind,
     futures::StreamExt,
     prost::Message,
     protobuf::{
@@ -41,7 +41,7 @@ const TEST_TIMEOUT_SECONDS: u64 = 5;
 
 async fn check(
     rpcs: EnabledRPCsInTest,
-    test_setup: fn(&corepc_node::Node, &corepc_node::Node),
+    test_setup: fn(&bitcoind::BitcoinD, &bitcoind::BitcoinD),
     check_expected: fn(PeerObserverEvent) -> (),
 ) {
     setup();

--- a/extractors/rpc/tests/integration.rs
+++ b/extractors/rpc/tests/integration.rs
@@ -3,9 +3,7 @@
 
 mod common;
 
-use common::{
-    EnabledRPCsInTest, get_available_port, make_test_args, setup, setup_two_connected_nodes,
-};
+use common::{EnabledRPCsInTest, make_test_args, setup, setup_two_connected_nodes};
 
 use shared::{
     async_nats,
@@ -29,7 +27,7 @@ use shared::{
     testing::{REGTEST_ADDRESS, nats_server::NatsServerForTesting},
     tokio::{
         self, select,
-        sync::watch,
+        sync::{oneshot, watch},
         time::{Duration, sleep},
     },
 };
@@ -48,7 +46,7 @@ async fn check(
     let (node1, node2) = setup_two_connected_nodes();
     let nats_server = NatsServerForTesting::new(&[]).await;
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
-    let metrics_port = get_available_port();
+    let (addr_tx, addr_rx) = oneshot::channel();
 
     let url = node1.rpc_url().replace("http://", "");
     let cookie_file_path = node1.params.cookie_file.display().to_string();
@@ -57,18 +55,26 @@ async fn check(
     test_setup(&node1, &node2);
     sleep(Duration::from_secs(1)).await;
 
-    let rpc_extractor_handle = tokio::spawn(async move {
-        let args = make_test_args(
-            nats_server.port,
-            url,
-            cookie_file_path,
-            format!("127.0.0.1:{}", metrics_port),
-            rpcs,
-        );
-        rpc_extractor::run(args, shutdown_rx.clone())
+    let mut rpc_extractor_handle = tokio::spawn(async move {
+        let args = make_test_args(nats_server.port, url, cookie_file_path, rpcs);
+        rpc_extractor::run(args, shutdown_rx.clone(), Some(addr_tx))
             .await
             .expect("rpc extractor failed");
     });
+
+    // Wait for the rpc-extractor to bind its Prometheus port and report
+    // the OS-assigned address back. Race against the task handle so that
+    // if the extractor fails before binding (e.g. NATS connection error),
+    // we surface the real error instead of a generic "channel closed" panic.
+    select! {
+        addr = addr_rx => {
+            addr.expect("rpc-extractor should send bound address");
+        }
+        result = &mut rpc_extractor_handle => {
+            result.unwrap();
+            unreachable!("rpc-extractor task exited before sending bound address");
+        }
+    }
 
     let nc = async_nats::connect(format!("127.0.0.1:{}", nats_server.port))
         .await

--- a/extractors/rpc/tests/metrics_integration.rs
+++ b/extractors/rpc/tests/metrics_integration.rs
@@ -4,8 +4,7 @@
 mod common;
 
 use common::{
-    EnabledRPCsInTest, QUERY_INTERVAL_SECONDS, get_available_port, make_test_args, setup,
-    setup_two_connected_nodes,
+    EnabledRPCsInTest, QUERY_INTERVAL_SECONDS, make_test_args, setup, setup_two_connected_nodes,
 };
 
 use shared::{
@@ -13,7 +12,10 @@ use shared::{
         metrics_fetcher::{fetch_metrics, get_metric_value},
         nats_server::NatsServerForTesting,
     },
-    tokio::{self, sync::watch},
+    tokio::{
+        self, select,
+        sync::{oneshot, watch},
+    },
 };
 
 /// Verifies the Prometheus metrics server starts and responds to HTTP requests.
@@ -23,23 +25,29 @@ async fn test_integration_metrics_server_basic() {
     let (node1, _node2) = setup_two_connected_nodes();
     let nats_server = NatsServerForTesting::new(&[]).await;
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
-    let metrics_port = get_available_port();
+    let (addr_tx, addr_rx) = oneshot::channel();
 
-    let rpc_extractor_handle = tokio::spawn(async move {
+    let mut rpc_extractor_handle = tokio::spawn(async move {
         let args = make_test_args(
             nats_server.port,
             node1.rpc_url().replace("http://", ""),
             node1.params.cookie_file.display().to_string(),
-            format!("127.0.0.1:{}", metrics_port),
             EnabledRPCsInTest {
                 ..Default::default()
             },
         );
-        let _ = rpc_extractor::run(args, shutdown_rx.clone()).await;
+        rpc_extractor::run(args, shutdown_rx.clone(), Some(addr_tx))
+            .await
+            .expect("rpc extractor failed");
     });
 
-    // Wait for the metrics server to start
-    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+    let metrics_port = select! {
+        addr = addr_rx => addr.expect("rpc-extractor should send bound address").port(),
+        result = &mut rpc_extractor_handle => {
+            result.unwrap();
+            unreachable!("rpc-extractor task exited before sending bound address");
+        }
+    };
 
     // Fetch metrics and verify the server responds
     let metrics = fetch_metrics(metrics_port, "/metrics");
@@ -64,21 +72,30 @@ async fn test_integration_metrics_rpc_fetch_duration() {
     let (node1, _node2) = setup_two_connected_nodes();
     let nats_server = NatsServerForTesting::new(&[]).await;
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
-    let metrics_port = get_available_port();
+    let (addr_tx, addr_rx) = oneshot::channel();
 
-    let rpc_extractor_handle = tokio::spawn(async move {
+    let mut rpc_extractor_handle = tokio::spawn(async move {
         let args = make_test_args(
             nats_server.port,
             node1.rpc_url().replace("http://", ""),
             node1.params.cookie_file.display().to_string(),
-            format!("127.0.0.1:{}", metrics_port),
             EnabledRPCsInTest {
                 uptime: true, // lightweight RPC
                 ..Default::default()
             },
         );
-        let _ = rpc_extractor::run(args, shutdown_rx.clone()).await;
+        rpc_extractor::run(args, shutdown_rx.clone(), Some(addr_tx))
+            .await
+            .expect("rpc extractor failed");
     });
+
+    let metrics_port = select! {
+        addr = addr_rx => addr.expect("rpc-extractor should send bound address").port(),
+        result = &mut rpc_extractor_handle => {
+            result.unwrap();
+            unreachable!("rpc-extractor task exited before sending bound address");
+        }
+    };
 
     // Wait for at least one RPC query cycle
     tokio::time::sleep(tokio::time::Duration::from_secs(QUERY_INTERVAL_SECONDS + 1)).await;
@@ -110,19 +127,28 @@ async fn test_integration_metrics_all_rpc_methods_duration() {
     let (node1, _node2) = setup_two_connected_nodes();
     let nats_server = NatsServerForTesting::new(&[]).await;
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
-    let metrics_port = get_available_port();
+    let (addr_tx, addr_rx) = oneshot::channel();
     let rpcs = EnabledRPCsInTest::all();
 
-    let rpc_extractor_handle = tokio::spawn(async move {
+    let mut rpc_extractor_handle = tokio::spawn(async move {
         let args = make_test_args(
             nats_server.port,
             node1.rpc_url().replace("http://", ""),
             node1.params.cookie_file.display().to_string(),
-            format!("127.0.0.1:{}", metrics_port),
             EnabledRPCsInTest::all(),
         );
-        let _ = rpc_extractor::run(args, shutdown_rx.clone()).await;
+        rpc_extractor::run(args, shutdown_rx.clone(), Some(addr_tx))
+            .await
+            .expect("rpc extractor failed");
     });
+
+    let metrics_port = select! {
+        addr = addr_rx => addr.expect("rpc-extractor should send bound address").port(),
+        result = &mut rpc_extractor_handle => {
+            result.unwrap();
+            unreachable!("rpc-extractor task exited before sending bound address");
+        }
+    };
 
     // Wait for at least one RPC query cycle
     tokio::time::sleep(tokio::time::Duration::from_secs(QUERY_INTERVAL_SECONDS + 1)).await;
@@ -156,27 +182,37 @@ async fn test_integration_metrics_rpc_fetch_errors() {
     setup();
     let nats_server = NatsServerForTesting::new(&[]).await;
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
-    let metrics_port = get_available_port();
+    let (addr_tx, addr_rx) = oneshot::channel();
 
-    // Create a temporary cookie file (required by Args validation)
+    // Create a temporary cookie file (required by Args validation). Use the
+    // NATS server port as a per-test-unique suffix.
     let temp_dir = std::env::temp_dir();
-    let cookie_file = temp_dir.join(format!("test_cookie_{}", metrics_port));
+    let cookie_file = temp_dir.join(format!("test_cookie_{}", nats_server.port));
     std::fs::write(&cookie_file, "__cookie__:test").expect("Failed to write cookie file");
 
     let cookie_file_path = cookie_file.display().to_string();
-    let rpc_extractor_handle = tokio::spawn(async move {
+    let mut rpc_extractor_handle = tokio::spawn(async move {
         let args = make_test_args(
             nats_server.port,
             "127.0.0.1:1".to_string(), // Unreachable RPC host
             cookie_file_path,
-            format!("127.0.0.1:{}", metrics_port),
             EnabledRPCsInTest {
                 uptime: true, // will fail
                 ..Default::default()
             },
         );
-        let _ = rpc_extractor::run(args, shutdown_rx.clone()).await;
+        rpc_extractor::run(args, shutdown_rx.clone(), Some(addr_tx))
+            .await
+            .expect("rpc extractor failed");
     });
+
+    let metrics_port = select! {
+        addr = addr_rx => addr.expect("rpc-extractor should send bound address").port(),
+        result = &mut rpc_extractor_handle => {
+            result.unwrap();
+            unreachable!("rpc-extractor task exited before sending bound address");
+        }
+    };
 
     // Wait for at least one RPC query cycle (which will fail)
     tokio::time::sleep(tokio::time::Duration::from_secs(QUERY_INTERVAL_SECONDS + 1)).await;
@@ -225,29 +261,39 @@ async fn test_integration_metrics_rpc_fetch_errors_invalid_auth() {
     let (node1, _node2) = setup_two_connected_nodes();
     let nats_server = NatsServerForTesting::new(&[]).await;
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
-    let metrics_port = get_available_port();
+    let (addr_tx, addr_rx) = oneshot::channel();
 
-    // Create a cookie file with invalid credentials
+    // Create a cookie file with invalid credentials. Use the NATS server
+    // port as a per-test-unique suffix.
     let temp_dir = std::env::temp_dir();
-    let invalid_cookie_file = temp_dir.join(format!("invalid_cookie_{}", metrics_port));
+    let invalid_cookie_file = temp_dir.join(format!("invalid_cookie_{}", nats_server.port));
     std::fs::write(&invalid_cookie_file, "__cookie__:invalid_password")
         .expect("Failed to write invalid cookie file");
 
     let invalid_cookie_path = invalid_cookie_file.display().to_string();
     let rpc_url = node1.rpc_url().replace("http://", "");
-    let rpc_extractor_handle = tokio::spawn(async move {
+    let mut rpc_extractor_handle = tokio::spawn(async move {
         let args = make_test_args(
             nats_server.port,
             rpc_url,
             invalid_cookie_path,
-            format!("127.0.0.1:{}", metrics_port),
             EnabledRPCsInTest {
                 uptime: true, // will fail due to auth
                 ..Default::default()
             },
         );
-        let _ = rpc_extractor::run(args, shutdown_rx.clone()).await;
+        rpc_extractor::run(args, shutdown_rx.clone(), Some(addr_tx))
+            .await
+            .expect("rpc extractor failed");
     });
+
+    let metrics_port = select! {
+        addr = addr_rx => addr.expect("rpc-extractor should send bound address").port(),
+        result = &mut rpc_extractor_handle => {
+            result.unwrap();
+            unreachable!("rpc-extractor task exited before sending bound address");
+        }
+    };
 
     // Wait for at least one RPC query cycle (which will fail due to invalid auth)
     tokio::time::sleep(tokio::time::Duration::from_secs(QUERY_INTERVAL_SECONDS + 1)).await;

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -24,11 +24,11 @@ regex = "1.12"
 
 # Use custom commit to support:
 # - cpu_load and inv_to_send in getpeerinfo
-# (branch 2026-04-corepc-0.12+custom-peer-observer-patches)
+# (branch 2026-05-corepc-0.12+custom-peer-observer-patches)
 # When updating the Bitcoin Core version used, grep for CORE_VERSION_GREP
 # and update the corepc_client::types::v* to the new version.
-corepc-node = { git = "https://github.com/0xb10c/corepc", rev = "9e4eb4d7181575ff75f9e0a6997b091bd5023b1d", features = ["download", "30_2"] }
-corepc-client = { git = "https://github.com/0xb10c/corepc", rev = "9e4eb4d7181575ff75f9e0a6997b091bd5023b1d", features = ["client-sync"]}
+bitcoind = { git = "https://github.com/0xb10c/corepc", rev = "8798e7f9c240c626dc3aa61adadeaf42f8221e40", features = ["download", "30_2"] }
+corepc-client = { git = "https://github.com/0xb10c/corepc", rev = "8798e7f9c240c626dc3aa61adadeaf42f8221e40", features = ["client-sync"]}
 
 [build-dependencies]
 prost-build = "0.14"

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -21,6 +21,7 @@ futures = "0.3.31"
 rand = "0.9.2"
 time = { version = "0.3.47", features = ["parsing"] }
 regex = "1.12"
+zstd = "0.13"
 
 # Use custom commit to support:
 # - cpu_load and inv_to_send in getpeerinfo

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -14,6 +14,7 @@ pub extern crate rand;
 pub extern crate serde;
 pub extern crate simple_logger;
 pub extern crate tokio;
+pub extern crate zstd;
 
 /// Mappings and implementation for the protobuf types used in NATS
 /// to communicate between the extractors and tools.

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -2,9 +2,9 @@
 
 pub extern crate async_nats;
 pub extern crate bitcoin;
+pub extern crate bitcoind;
 pub extern crate clap;
 pub extern crate corepc_client;
-pub extern crate corepc_node;
 pub extern crate futures;
 pub extern crate lazy_static;
 pub extern crate log;

--- a/shared/src/metricserver.rs
+++ b/shared/src/metricserver.rs
@@ -5,6 +5,7 @@ use std::error;
 use std::fmt;
 use std::io;
 use std::io::{Read, Write};
+use std::net::SocketAddr;
 use std::net::TcpListener;
 use std::net::TcpStream;
 use std::string::FromUtf8Error;
@@ -15,7 +16,10 @@ const LOG_TARGET: &str = "metricserver";
 // This is a minimal, per request thread spawning, and incorrect HTTP server
 // which answers on all request methods with prometheus formatted metrics.
 
-pub fn start(prometheus_address: &str, registry: Option<Registry>) -> Result<(), io::Error> {
+pub fn start(
+    prometheus_address: &str,
+    registry: Option<Registry>,
+) -> Result<SocketAddr, io::Error> {
     let listener = TcpListener::bind(prometheus_address)?;
     let local_addr = listener.local_addr()?;
     log::info!(
@@ -42,7 +46,7 @@ pub fn start(prometheus_address: &str, registry: Option<Registry>) -> Result<(),
             };
         }
     });
-    Ok(())
+    Ok(local_addr)
 }
 
 fn handle_request(

--- a/shared/src/protobuf/rpc_extractor.rs
+++ b/shared/src/protobuf/rpc_extractor.rs
@@ -12,7 +12,7 @@ use corepc_client::types::v30::{
 };
 
 // Ideally, all type imports should use the generic mtype types.
-use corepc_node::mtype::{
+use bitcoind::mtype::{
     EstimateSmartFee as RPCEstimateSmartFee, GetBlockchainInfo, GetChainTxStats, GetMempoolInfo,
     GetNetworkInfo, GetNetworkInfoAddress, GetNetworkInfoNetwork, GetOrphanTxsVerboseTwo,
     GetOrphanTxsVerboseTwoEntry,
@@ -390,7 +390,7 @@ impl From<GetBlockchainInfo> for BlockchainInfo {
             size_on_disk: info.size_on_disk,
             pruned: info.pruned,
             prune_height: info.prune_height.unwrap_or_default(),
-            prune_target_size: info.prune_target_size.map(|s| s as u64).unwrap_or_default(),
+            prune_target_size: info.prune_target_size.unwrap_or_default(),
             warnings: info.warnings,
         }
     }

--- a/shell.nix
+++ b/shell.nix
@@ -14,6 +14,9 @@ pkgs.mkShell {
       pkgs.cmake
       pkgs.protobuf
 
+      # needed for the archiver to figure out the current git commit
+      pkgs.git
+ 
       pkgs.rustfmt
 
       pkgs.bpftools

--- a/tools/alerts/Cargo.toml
+++ b/tools/alerts/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "alerts"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+shared = { path = "../../shared" }
+
+[features]
+# Treat warnings as a build error.
+strict = []
+# Run integration tests needing a NATS server.
+nats_integration_tests = []

--- a/tools/alerts/README.md
+++ b/tools/alerts/README.md
@@ -1,0 +1,100 @@
+# alerts
+
+A peer-observer tool that subscribes to NATS events and emits alerts when anomalous
+peer behavior is detected.
+
+## Heuristics
+
+### PingSpammer
+
+Detects peers that send more than `--ping-threshold` inbound `ping` messages within a
+`--ping-window-secs` second sliding window.
+
+Alert format (as rendered by `LoggingAlerter`):
+```
+PingSpammer | peer_id=<id> addr=<addr> | <count> pings in last <secs>s (threshold: <threshold>)
+```
+
+### AddrSpammer
+
+Detects peers that send more than `--addr-threshold` inbound `addr` or `addrv2` messages
+within an `--addr-window-secs` second sliding window. Both message types are counted in
+the same window.
+
+Alert format (as rendered by `LoggingAlerter`):
+```
+AddrSpammer | peer_id=<id> addr=<addr> | <count> addr/addrv2 messages in last <secs>s (threshold: <threshold>)
+```
+
+Each peer/kind combination fires at most one alert per session (one-shot).
+
+## Peer lifecycle
+
+When a previously flagged peer disconnects (either via a `ConnectionEvent::Close`
+or by being evicted after `--peer-stale-secs` of inactivity), the same `Alerter`
+emits a `PeerDisconnected` alert with the duration of the spamming episode:
+
+```
+PeerDisconnected | peer_id=<id> addr=<addr> | active=<duration>s
+```
+
+Non-flagged peers disconnect silently (no alert is emitted).
+
+## Usage
+
+```
+cargo run -p alerts -- [OPTIONS]
+```
+
+## Options
+
+```
+Arguments for the connection the the NATS server that each extractor and tool needs
+
+Usage: alerts [OPTIONS]
+
+Options:
+  -a, --nats-address <ADDRESS>
+          The NATS server address the extractor/tool should connect and subscribe to [default: 127.0.0.1:4222]
+  -u, --nats-username <USERNAME>
+          The NATS username the extractor/tool should try to authentificate to the NATS server with
+  -p, --nats-password <PASSWORD>
+          The NATS password the extractor/tool should try to authentificate to the NATS server with
+  -f, --nats-password-file <PASSWORD_FILE>
+          A path to a file containing a password the extractor/tool should try to authentificate to the NATS server with
+      --ping-threshold <PING_THRESHOLD>
+          Number of pings in the window before alerting [default: 3]
+      --ping-window-secs <PING_WINDOW_SECS>
+          Sliding window size for ping detection (seconds) [default: 120]
+      --addr-threshold <ADDR_THRESHOLD>
+          Number of addr/addrv2 messages in the window before alerting [default: 6]
+      --addr-window-secs <ADDR_WINDOW_SECS>
+          Sliding window size for addr detection (seconds) [default: 60]
+  -l, --log-level <LOG_LEVEL>
+          [default: DEBUG]
+      --peer-stale-secs <PEER_STALE_SECS>
+          Remove peers not seen for this many seconds (prevents OOM on missed Close events) [default: 300]
+  -h, --help
+          Print help
+  -V, --version
+          Print version
+```
+
+## Example
+
+```bash
+# Use low thresholds for testing
+cargo run -p alerts -- \
+  --nats-address nats://localhost:4222 \
+  --ping-threshold 3 \
+  --ping-window-secs 30 \
+  --addr-threshold 2 \
+  --addr-window-secs 60
+```
+
+Example output:
+```
+INFO  [alerts::alerter] PingSpammer | peer_id=42 addr=1.2.3.4:8333 | 4 pings in last 30s (threshold: 3)
+INFO  [alerts::alerter] AddrSpammer | peer_id=7 addr=5.6.7.8:8333 | 3 addr/addrv2 messages in last 60s (threshold: 2)
+INFO  [alerts::alerter] PeerDisconnected | peer_id=42 addr=1.2.3.4:8333 | active=47s
+```

--- a/tools/alerts/src/alerter.rs
+++ b/tools/alerts/src/alerter.rs
@@ -1,0 +1,101 @@
+use shared::log;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum SpammerKind {
+    Ping,
+    Addr,
+}
+
+/// Every observation the alerts tool publishes flows through this enum
+/// `Spammer` is emitted when a peer crosses a configured threshold once
+/// `PeerDisconnected` is emitted when a previously-flagged peer disconnects
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Alert {
+    Spammer {
+        kind: SpammerKind,
+        peer_id: u64,
+        addr: String,
+        count: usize,
+        window_secs: u64,
+        threshold: usize,
+    },
+    PeerDisconnected {
+        peer_id: u64,
+        addr: String,
+        active_secs: u64,
+    },
+}
+
+impl std::fmt::Display for Alert {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Alert::Spammer {
+                kind,
+                peer_id,
+                addr,
+                count,
+                window_secs,
+                threshold,
+            } => {
+                let (name, unit) = match kind {
+                    SpammerKind::Ping => ("PingSpammer", "pings"),
+                    SpammerKind::Addr => ("AddrSpammer", "addr/addrv2 messages"),
+                };
+                write!(
+                    f,
+                    "{} | peer_id={} addr={} | {} {} in last {}s (threshold: {})",
+                    name, peer_id, addr, count, unit, window_secs, threshold
+                )
+            }
+            Alert::PeerDisconnected {
+                peer_id,
+                addr,
+                active_secs,
+            } => write!(
+                f,
+                "PeerDisconnected | peer_id={} addr={} | active={}s",
+                peer_id, addr, active_secs
+            ),
+        }
+    }
+}
+
+/// Output sink for alerts. Implementations decide how alerts are published
+///
+/// `emit` is called from the event loop and must not block. Sinks that do I/O
+/// (HTTP, NATS publish, Prometheus push, etc.) must own a background task and
+/// hand off the alert through a channel — do the network work there, not here
+pub trait Alerter: Send + Sync {
+    fn emit(&self, alert: Alert);
+}
+
+/// Default alerter: writes each alert to the logger at `info!` level
+pub struct LoggingAlerter;
+
+impl Alerter for LoggingAlerter {
+    fn emit(&self, alert: Alert) {
+        log::info!("{}", alert);
+    }
+}
+
+/// Alerter that pushes each emitted alert through an mpsc channel
+/// Lets tests assert on structured alerts instead of parsing log output
+#[cfg(any(test, feature = "nats_integration_tests"))]
+pub struct IntegrationTestAlerter {
+    tx: shared::tokio::sync::mpsc::UnboundedSender<Alert>,
+}
+
+#[cfg(any(test, feature = "nats_integration_tests"))]
+impl IntegrationTestAlerter {
+    pub fn new() -> (Self, shared::tokio::sync::mpsc::UnboundedReceiver<Alert>) {
+        let (tx, rx) = shared::tokio::sync::mpsc::unbounded_channel();
+        (Self { tx }, rx)
+    }
+}
+
+#[cfg(any(test, feature = "nats_integration_tests"))]
+impl Alerter for IntegrationTestAlerter {
+    fn emit(&self, alert: Alert) {
+        let _ = self.tx.send(alert);
+    }
+}

--- a/tools/alerts/src/error.rs
+++ b/tools/alerts/src/error.rs
@@ -1,0 +1,50 @@
+use shared::async_nats;
+use shared::async_nats::ConnectError;
+use std::error;
+use std::fmt;
+use std::io;
+
+#[derive(Debug)]
+pub enum RuntimeError {
+    NatsSubscribe(async_nats::client::SubscribeError),
+    NatsConnect(ConnectError),
+    Io(io::Error),
+}
+
+impl fmt::Display for RuntimeError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            RuntimeError::NatsSubscribe(e) => write!(f, "NATS subscribe error {}", e),
+            RuntimeError::NatsConnect(e) => write!(f, "NATS connection error {}", e),
+            RuntimeError::Io(e) => write!(f, "IO error {}", e),
+        }
+    }
+}
+
+impl error::Error for RuntimeError {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match *self {
+            RuntimeError::NatsSubscribe(ref e) => Some(e),
+            RuntimeError::NatsConnect(ref e) => Some(e),
+            RuntimeError::Io(ref e) => Some(e),
+        }
+    }
+}
+
+impl From<async_nats::client::SubscribeError> for RuntimeError {
+    fn from(e: async_nats::client::SubscribeError) -> Self {
+        RuntimeError::NatsSubscribe(e)
+    }
+}
+
+impl From<ConnectError> for RuntimeError {
+    fn from(e: ConnectError) -> Self {
+        RuntimeError::NatsConnect(e)
+    }
+}
+
+impl From<io::Error> for RuntimeError {
+    fn from(e: io::Error) -> Self {
+        RuntimeError::Io(e)
+    }
+}

--- a/tools/alerts/src/lib.rs
+++ b/tools/alerts/src/lib.rs
@@ -1,0 +1,470 @@
+#![cfg_attr(feature = "strict", deny(warnings))]
+
+use shared::clap;
+use shared::clap::Parser;
+use shared::futures::stream::StreamExt;
+use shared::log;
+use shared::nats_subjects::Subject;
+use shared::nats_util;
+use shared::nats_util::NatsArgs;
+use shared::prost::Message;
+use shared::protobuf::ebpf_extractor::connection::connection_event;
+use shared::protobuf::ebpf_extractor::ebpf;
+use shared::protobuf::ebpf_extractor::message::message_event::Msg;
+use shared::protobuf::event::Event;
+use shared::tokio::sync::watch;
+use std::collections::{HashMap, VecDeque};
+use std::time::{Duration, Instant};
+
+use crate::error::RuntimeError;
+
+pub mod alerter;
+pub mod error;
+
+pub use crate::alerter::{Alert, Alerter, LoggingAlerter, SpammerKind};
+
+#[derive(Parser, Debug, Clone)]
+#[command(version, about, long_about = None)]
+pub struct Args {
+    /// Arguments for the connection to the NATS server
+    #[command(flatten)]
+    pub nats: NatsArgs,
+
+    /// Number of pings in the window before alerting
+    #[arg(long, default_value_t = 3)]
+    pub ping_threshold: usize,
+
+    /// Sliding window size for ping detection (seconds)
+    #[arg(long, default_value_t = 120)]
+    pub ping_window_secs: u64,
+
+    /// Number of addr/addrv2 messages in the window before alerting
+    #[arg(long, default_value_t = 6)]
+    pub addr_threshold: usize,
+
+    /// Sliding window size for addr detection (seconds)
+    #[arg(long, default_value_t = 60)]
+    pub addr_window_secs: u64,
+
+    #[arg(short, long, default_value_t = shared::log::Level::Debug)]
+    pub log_level: shared::log::Level,
+
+    /// Remove peers not seen for this many seconds (prevents OOM on missed Close events)
+    #[arg(long, default_value_t = 300)]
+    pub peer_stale_secs: u64,
+}
+
+#[derive(Default)]
+struct AlertTypeState {
+    timestamps: VecDeque<Instant>,
+    alerted_at: Option<Instant>,
+}
+
+struct PeerState {
+    ping: AlertTypeState,
+    addr: AlertTypeState,
+    last_seen: Instant,
+    peer_addr: String,
+}
+
+impl PeerState {
+    fn new(peer_addr: String, now: Instant) -> Self {
+        PeerState {
+            ping: AlertTypeState::default(),
+            addr: AlertTypeState::default(),
+            last_seen: now,
+            peer_addr,
+        }
+    }
+
+    /// Records a hit for `kind` and returns an `Alert` the first time the
+    /// threshold is exceeded. After alerting once, subsequent hits are dropped
+    /// and the function returns `None` without growing the sliding window
+    fn check(
+        &mut self,
+        kind: SpammerKind,
+        peer_id: u64,
+        now: Instant,
+        args: &Args,
+    ) -> Option<Alert> {
+        let (state, window_secs, threshold) = match kind {
+            SpammerKind::Ping => (&mut self.ping, args.ping_window_secs, args.ping_threshold),
+            SpammerKind::Addr => (&mut self.addr, args.addr_window_secs, args.addr_threshold),
+        };
+
+        if state.alerted_at.is_some() {
+            return None;
+        }
+
+        state.timestamps.push_back(now);
+        let window = Duration::from_secs(window_secs);
+        while state
+            .timestamps
+            .front()
+            .is_some_and(|t| now.duration_since(*t) > window)
+        {
+            state.timestamps.pop_front();
+        }
+        if state.timestamps.len() <= threshold {
+            return None;
+        }
+        let count = state.timestamps.len();
+        state.alerted_at = Some(now);
+
+        Some(Alert::Spammer {
+            kind,
+            peer_id,
+            addr: self.peer_addr.clone(),
+            count,
+            window_secs,
+            threshold,
+        })
+    }
+}
+
+struct AlertState {
+    peers: HashMap<u64, PeerState>,
+}
+
+impl AlertState {
+    fn new() -> Self {
+        AlertState {
+            peers: HashMap::new(),
+        }
+    }
+}
+
+/// Builds a `PeerDisconnected` alert for peers that were previously flagged as
+/// spammers, including how long they were active. Returns `None` for peers
+/// that were never flagged so non-flagged disconnects stay silent
+fn disconnect_alert(peer_id: u64, peer: &PeerState, now: Instant) -> Option<Alert> {
+    let first_alerted = [peer.ping.alerted_at, peer.addr.alerted_at]
+        .into_iter()
+        .flatten()
+        .min()?;
+    Some(Alert::PeerDisconnected {
+        peer_id,
+        addr: peer.peer_addr.clone(),
+        active_secs: now.duration_since(first_alerted).as_secs(),
+    })
+}
+
+/// Removes peers that haven't sent any message in `stale_after`
+/// Emits a `PeerDisconnected` alert for any flagged peers evicted this way
+fn cleanup_stale_peers(
+    state: &mut AlertState,
+    stale_after: Duration,
+    now: Instant,
+    alerter: &impl Alerter,
+) {
+    let stale: Vec<u64> = state
+        .peers
+        .iter()
+        .filter(|(_, p)| now.duration_since(p.last_seen) > stale_after)
+        .map(|(id, _)| *id)
+        .collect();
+    for peer_id in stale {
+        if let Some(peer) = state.peers.remove(&peer_id) {
+            if let Some(alert) = disconnect_alert(peer_id, &peer, now) {
+                alerter.emit(alert);
+            }
+        }
+    }
+}
+
+/// Connects to NATS, subscribes to all subjects, and dispatches each
+/// received event to `handle_event`. Alerts are emitted through `alerter`
+pub async fn run<A: Alerter>(
+    args: Args,
+    alerter: A,
+    mut shutdown_rx: watch::Receiver<bool>,
+) -> Result<(), RuntimeError> {
+    log::info!("starting alerts with {:?}", args);
+
+    let nc = nats_util::prepare_connection(&args.nats)?
+        .connect(&args.nats.address)
+        .await?;
+
+    let netmsg_sub = nc.subscribe(Subject::NetMsg.to_string()).await?;
+    let netconn_sub = nc.subscribe(Subject::NetConn.to_string()).await?;
+    let mut sub = shared::futures::stream::select(netmsg_sub, netconn_sub);
+    log::info!("Connected to NATS-server at {}", args.nats.address);
+
+    let mut state = AlertState::new();
+
+    let stale_after = Duration::from_secs(args.peer_stale_secs);
+    let mut cleanup_interval = shared::tokio::time::interval(stale_after);
+    cleanup_interval.tick().await;
+
+    loop {
+        shared::tokio::select! {
+            maybe_msg = sub.next() => {
+                match maybe_msg {
+                    Some(msg) => match Event::decode(msg.payload) {
+                        Ok(event) => handle_event(event, &mut state, &args, &alerter),
+                        Err(e) => log::warn!("dropping undecodable NATS payload: {e}"),
+                    },
+                    None => break,
+                }
+            }
+            _ = cleanup_interval.tick() => {
+                cleanup_stale_peers(&mut state, stale_after, Instant::now(), &alerter);
+            }
+            res = shutdown_rx.changed() => {
+                match res {
+                    Ok(_) => {
+                        if *shutdown_rx.borrow() {
+                            log::info!("alerts tool received shutdown signal.");
+                            break;
+                        }
+                    }
+                    Err(_) => {
+                        log::warn!("The shutdown notification sender was dropped. Shutting down.");
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Routes a NATS event to the appropriate handler
+fn handle_event(event: Event, state: &mut AlertState, args: &Args, alerter: &impl Alerter) {
+    let now = Instant::now();
+    if let Some(shared::protobuf::event::event::PeerObserverEvent::EbpfExtractor(ebpf)) =
+        event.peer_observer_event
+    {
+        match ebpf.ebpf_event {
+            Some(ebpf::EbpfEvent::Message(msg)) => handle_message(msg, state, args, alerter, now),
+            Some(ebpf::EbpfEvent::Connection(conn)) => handle_connection(conn, state, now, alerter),
+            _ => {}
+        }
+    }
+}
+
+/// Processes an inbound P2P message. Drops outbound messages and dispatches
+/// to ping or addr spammer detection based on the message type
+fn handle_message(
+    msg: shared::protobuf::ebpf_extractor::message::MessageEvent,
+    state: &mut AlertState,
+    args: &Args,
+    alerter: &impl Alerter,
+    now: Instant,
+) {
+    if !msg.meta.inbound {
+        return;
+    }
+
+    let peer_id = msg.meta.peer_id;
+    let addr = &msg.meta.addr;
+
+    let peer = state
+        .peers
+        .entry(peer_id)
+        .or_insert_with(|| PeerState::new(addr.clone(), now));
+    peer.last_seen = now;
+
+    let kind = match msg.msg {
+        Some(Msg::Ping(_)) => SpammerKind::Ping,
+        Some(Msg::Addr(_)) | Some(Msg::Addrv2(_)) => SpammerKind::Addr,
+        _ => return,
+    };
+
+    if let Some(alert) = peer.check(kind, peer_id, now, args) {
+        alerter.emit(alert);
+    }
+}
+
+/// Cleans up peer state when a connection closes and emits a
+/// `PeerDisconnected` alert if the peer was previously flagged
+fn handle_connection(
+    conn: shared::protobuf::ebpf_extractor::connection::ConnectionEvent,
+    state: &mut AlertState,
+    now: Instant,
+    alerter: &impl Alerter,
+) {
+    if let Some(connection_event::Event::Closed(c)) = conn.event {
+        let peer_id = c.conn.peer_id;
+        if let Some(peer) = state.peers.remove(&peer_id) {
+            if let Some(alert) = disconnect_alert(peer_id, &peer, now) {
+                alerter.emit(alert);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_args(ping_threshold: usize, addr_threshold: usize, window_secs: u64) -> Args {
+        Args {
+            nats: NatsArgs {
+                address: "127.0.0.1:4222".to_string(),
+                username: None,
+                password: None,
+                password_file: None,
+            },
+            ping_threshold,
+            ping_window_secs: window_secs,
+            addr_threshold,
+            addr_window_secs: window_secs,
+            log_level: shared::log::Level::Trace,
+            peer_stale_secs: 300,
+        }
+    }
+
+    fn make_peer(now: Instant) -> PeerState {
+        PeerState::new("1.2.3.4:8333".to_string(), now)
+    }
+
+    fn unwrap_spammer(alert: Alert) -> (SpammerKind, u64, usize, u64, usize) {
+        match alert {
+            Alert::Spammer {
+                kind,
+                peer_id,
+                count,
+                window_secs,
+                threshold,
+                ..
+            } => (kind, peer_id, count, window_secs, threshold),
+            other => panic!("expected Alert::Spammer, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn below_threshold_no_alert() {
+        let args = test_args(3, 3, 60);
+        let t0 = Instant::now();
+        let mut peer = make_peer(t0);
+
+        // threshold=3 means "more than 3"; 3 hits must not fire
+        for i in 0..3 {
+            let now = t0 + Duration::from_millis(i);
+            assert!(peer.check(SpammerKind::Ping, 1, now, &args).is_none());
+        }
+    }
+
+    #[test]
+    fn above_threshold_fires_once() {
+        let args = test_args(3, 3, 60);
+        let t0 = Instant::now();
+        let mut peer = make_peer(t0);
+
+        for i in 0..3 {
+            peer.check(SpammerKind::Ping, 1, t0 + Duration::from_millis(i), &args);
+        }
+        let alert = peer
+            .check(SpammerKind::Ping, 1, t0 + Duration::from_millis(4), &args)
+            .expect("4th hit over threshold=3 must emit an alert");
+        let (kind, peer_id, count, _, threshold) = unwrap_spammer(alert);
+        assert_eq!(kind, SpammerKind::Ping);
+        assert_eq!(peer_id, 1);
+        assert_eq!(count, 4);
+        assert_eq!(threshold, 3);
+    }
+
+    #[test]
+    fn one_shot_no_retrigger() {
+        let args = test_args(3, 3, 60);
+        let t0 = Instant::now();
+        let mut peer = make_peer(t0);
+
+        // Cross the threshold
+        for i in 0..4 {
+            peer.check(SpammerKind::Ping, 1, t0 + Duration::from_millis(i), &args);
+        }
+        assert!(peer.ping.alerted_at.is_some());
+        let len_at_alert = peer.ping.timestamps.len();
+
+        // 10 more hits — none should alert, and the deque must not grow
+        for i in 4..14 {
+            assert!(peer
+                .check(SpammerKind::Ping, 1, t0 + Duration::from_millis(i), &args)
+                .is_none());
+        }
+        assert_eq!(
+            peer.ping.timestamps.len(),
+            len_at_alert,
+            "deque must not grow after the one-shot alert fires"
+        );
+    }
+
+    #[test]
+    fn out_of_window_hits_dropped() {
+        let args = test_args(3, 3, 60);
+        let t0 = Instant::now();
+        let mut peer = make_peer(t0);
+
+        // Two hits at t0
+        peer.check(SpammerKind::Ping, 1, t0, &args);
+        peer.check(SpammerKind::Ping, 1, t0 + Duration::from_secs(1), &args);
+
+        // Advance past the window (60s) so the first two fall out
+        let later = t0 + Duration::from_secs(90);
+        for i in 0..3 {
+            assert!(peer
+                .check(
+                    SpammerKind::Ping,
+                    1,
+                    later + Duration::from_millis(i),
+                    &args
+                )
+                .is_none());
+        }
+        assert_eq!(
+            peer.ping.timestamps.len(),
+            3,
+            "only the 3 recent hits should remain in the sliding window"
+        );
+    }
+
+    #[test]
+    fn separate_counters_per_kind() {
+        let args = test_args(3, 10, 60);
+        let t0 = Instant::now();
+        let mut peer = make_peer(t0);
+
+        // 4 addr messages — below addr_threshold=10 — must not alert
+        for i in 0..4 {
+            assert!(peer
+                .check(SpammerKind::Addr, 1, t0 + Duration::from_millis(i), &args)
+                .is_none());
+        }
+
+        // 4 pings — above ping_threshold=3 — the 4th one must alert
+        let mut ping_alerted = false;
+        for i in 1..=4 {
+            if peer
+                .check(SpammerKind::Ping, 1, t0 + Duration::from_secs(i), &args)
+                .is_some()
+            {
+                ping_alerted = true;
+            }
+        }
+        assert!(ping_alerted, "4 pings with threshold=3 must alert");
+
+        // Addr counter must still not have fired
+        assert!(peer.addr.alerted_at.is_none());
+    }
+
+    #[test]
+    fn addr_alert_carries_addr_window_fields() {
+        let args = test_args(100, 2, 60);
+        let t0 = Instant::now();
+        let mut peer = make_peer(t0);
+
+        for i in 0..2 {
+            peer.check(SpammerKind::Addr, 7, t0 + Duration::from_millis(i), &args);
+        }
+        let alert = peer
+            .check(SpammerKind::Addr, 7, t0 + Duration::from_millis(3), &args)
+            .expect("3rd hit with addr_threshold=2 must alert");
+        let (kind, _, count, window_secs, threshold) = unwrap_spammer(alert);
+        assert_eq!(kind, SpammerKind::Addr);
+        assert_eq!(window_secs, args.addr_window_secs);
+        assert_eq!(threshold, args.addr_threshold);
+        assert_eq!(count, 3);
+    }
+}

--- a/tools/alerts/src/main.rs
+++ b/tools/alerts/src/main.rs
@@ -1,0 +1,29 @@
+use alerts::{Args, LoggingAlerter};
+use shared::log;
+use shared::tokio::{self, signal, sync::watch};
+use shared::{clap::Parser, simple_logger};
+
+#[tokio::main]
+async fn main() {
+    let args = Args::parse();
+
+    if let Err(e) = simple_logger::init_with_level(args.log_level) {
+        eprintln!("alerts tool error: {}", e);
+    }
+
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let alerts_handle = tokio::spawn(alerts::run(args, LoggingAlerter, shutdown_rx));
+
+    tokio::select! {
+        _ = signal::ctrl_c() => {
+            log::info!("Received Ctrl+C. Stopping...");
+            let _ = shutdown_tx.send(true);
+        }
+        result = alerts_handle => {
+            match result.unwrap() {
+                Ok(_) => log::info!("alerts task completed."),
+                Err(e) => log::error!("alerts task failed: {e}"),
+            }
+        }
+    }
+}

--- a/tools/alerts/tests/integration.rs
+++ b/tools/alerts/tests/integration.rs
@@ -1,0 +1,498 @@
+#![cfg(feature = "nats_integration_tests")]
+
+use alerts::{alerter::IntegrationTestAlerter, error::RuntimeError, Alert, Args, SpammerKind};
+
+use shared::{
+    log,
+    nats_subjects::Subject,
+    nats_util,
+    prost::Message,
+    protobuf::{
+        ebpf_extractor::{
+            connection::{self, ClosedConnection, Connection, ConnectionEvent},
+            ebpf,
+            message::{self, message_event::Msg, Addr, AddrV2, Metadata, Ping},
+            Ebpf,
+        },
+        event::{event::PeerObserverEvent, Event},
+    },
+    testing::{nats_publisher::NatsPublisherForTesting, nats_server::NatsServerForTesting},
+    tokio::{
+        self,
+        sync::{mpsc::UnboundedReceiver, watch},
+        time::{sleep, timeout},
+    },
+};
+
+use std::time::Duration;
+
+/// Builds an `Args` instance pointing at the given NATS server
+fn make_test_args(
+    nats_port: u16,
+    ping_threshold: usize,
+    ping_window_secs: u64,
+    addr_threshold: usize,
+    addr_window_secs: u64,
+    peer_stale_secs: u64,
+) -> Args {
+    Args {
+        nats: nats_util::NatsArgs {
+            address: format!("127.0.0.1:{}", nats_port),
+            username: None,
+            password: None,
+            password_file: None,
+        },
+        ping_threshold,
+        ping_window_secs,
+        addr_threshold,
+        addr_window_secs,
+        log_level: log::Level::Trace,
+        peer_stale_secs,
+    }
+}
+
+/// Waits up to `d` for the next alert; panics if none arrives
+async fn recv_alert(rx: &mut UnboundedReceiver<Alert>, d: Duration) -> Alert {
+    timeout(d, rx.recv())
+        .await
+        .expect("timed out waiting for alert")
+        .expect("alerter channel closed unexpectedly")
+}
+
+/// Returns true iff no alert arrives within `d`
+async fn expect_no_alert(rx: &mut UnboundedReceiver<Alert>, d: Duration) -> bool {
+    timeout(d, rx.recv()).await.is_err()
+}
+
+/// Destructures `Alert::Spammer` for assertions; panics on any other variant
+fn unwrap_spammer(alert: Alert) -> (SpammerKind, u64, usize, usize) {
+    match alert {
+        Alert::Spammer {
+            kind,
+            peer_id,
+            count,
+            threshold,
+            ..
+        } => (kind, peer_id, count, threshold),
+        other => panic!("expected Alert::Spammer, got {other:?}"),
+    }
+}
+
+/// Publishes the same protobuf event `n` times on the given NATS subject
+async fn publish_n(publisher: &NatsPublisherForTesting, subject: &str, event: &Event, n: usize) {
+    let payload = event.encode_to_vec();
+    for _ in 0..n {
+        publisher
+            .publish(subject.to_string(), payload.clone())
+            .await;
+    }
+}
+
+/// Constructs a protobuf `Event` wrapping a `Ping` message for the given peer
+/// `inbound` controls whether the message appears as received from the peer
+fn make_ping_event(peer_id: u64, addr: &str, inbound: bool) -> Event {
+    Event::new(PeerObserverEvent::EbpfExtractor(Ebpf {
+        ebpf_event: Some(ebpf::EbpfEvent::Message(message::MessageEvent {
+            meta: Metadata {
+                peer_id,
+                addr: addr.to_string(),
+                conn_type: 1,
+                command: "ping".to_string(),
+                inbound,
+                size: 8,
+            },
+            msg: Some(Msg::Ping(Ping { value: 42 })),
+        })),
+    }))
+    .unwrap()
+}
+
+/// Constructs an inbound `Addr` message event for the given peer
+fn make_addr_event(peer_id: u64, addr: &str) -> Event {
+    Event::new(PeerObserverEvent::EbpfExtractor(Ebpf {
+        ebpf_event: Some(ebpf::EbpfEvent::Message(message::MessageEvent {
+            meta: Metadata {
+                peer_id,
+                addr: addr.to_string(),
+                conn_type: 1,
+                command: "addr".to_string(),
+                inbound: true,
+                size: 30,
+            },
+            msg: Some(Msg::Addr(Addr { addresses: vec![] })),
+        })),
+    }))
+    .unwrap()
+}
+
+/// Constructs an inbound `AddrV2` message event for the given peer
+fn make_addrv2_event(peer_id: u64, addr: &str) -> Event {
+    Event::new(PeerObserverEvent::EbpfExtractor(Ebpf {
+        ebpf_event: Some(ebpf::EbpfEvent::Message(message::MessageEvent {
+            meta: Metadata {
+                peer_id,
+                addr: addr.to_string(),
+                conn_type: 1,
+                command: "addrv2".to_string(),
+                inbound: true,
+                size: 30,
+            },
+            msg: Some(Msg::Addrv2(AddrV2 { addresses: vec![] })),
+        })),
+    }))
+    .unwrap()
+}
+
+/// Builds a ClosedConnection event for the given peer/addr
+fn make_closed_event(peer_id: u64, addr: &str) -> Event {
+    Event::new(PeerObserverEvent::EbpfExtractor(Ebpf {
+        ebpf_event: Some(ebpf::EbpfEvent::Connection(ConnectionEvent {
+            event: Some(connection::connection_event::Event::Closed(
+                ClosedConnection {
+                    conn: Connection {
+                        peer_id,
+                        addr: addr.to_string(),
+                        conn_type: 1,
+                        network: 1,
+                    },
+                    time_established: 0,
+                },
+            )),
+        })),
+    }))
+    .unwrap()
+}
+
+/// Boilerplate-collecting harness for integration tests.
+/// Spins up a NATS server + publisher, an `IntegrationTestAlerter`, and the
+/// `alerts::run` task. `shutdown` cleanly stops the task at the end of a test
+struct TestHarness {
+    publisher: NatsPublisherForTesting,
+    rx: UnboundedReceiver<Alert>,
+    shutdown_tx: watch::Sender<bool>,
+    handle: tokio::task::JoinHandle<Result<(), RuntimeError>>,
+    _server: NatsServerForTesting,
+}
+
+impl TestHarness {
+    /// `mk_args` receives the NATS port and returns the `Args` to pass to `run`
+    /// so each test can pin its own thresholds while reusing the harness setup
+    async fn new(mk_args: impl FnOnce(u16) -> Args) -> Self {
+        let server = NatsServerForTesting::new(&[]).await;
+        let publisher = NatsPublisherForTesting::new(server.port).await;
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        let (alerter, rx) = IntegrationTestAlerter::new();
+        let args = mk_args(server.port);
+        let handle = tokio::spawn(alerts::run(args, alerter, shutdown_rx));
+        sleep(Duration::from_secs(1)).await;
+        Self {
+            publisher,
+            rx,
+            shutdown_tx,
+            handle,
+            _server: server,
+        }
+    }
+
+    async fn shutdown(self) {
+        self.shutdown_tx.send(true).unwrap();
+        self.handle.await.unwrap().unwrap();
+    }
+}
+
+/// Verifies the PingSpammer threshold boundary: exactly `threshold` pings stay
+/// silent; the (threshold + 1)-th ping fires the alert
+#[tokio::test]
+async fn test_ping_spammer() {
+    let ping_threshold = 3;
+    let mut harness =
+        TestHarness::new(|port| make_test_args(port, ping_threshold, 60, 5, 60, 3600)).await;
+
+    let event = make_ping_event(1, "1.2.3.4:8333", true);
+    let subject = Subject::NetMsg.to_string();
+
+    publish_n(&harness.publisher, &subject, &event, ping_threshold).await;
+    assert!(
+        expect_no_alert(&mut harness.rx, Duration::from_millis(500)).await,
+        "exactly threshold pings must not fire an alert"
+    );
+
+    publish_n(&harness.publisher, &subject, &event, 1).await;
+    let alert = recv_alert(&mut harness.rx, Duration::from_secs(2)).await;
+    let (kind, peer_id, count, threshold) = unwrap_spammer(alert);
+    assert_eq!(kind, SpammerKind::Ping);
+    assert_eq!(peer_id, 1);
+    assert_eq!(count, ping_threshold + 1);
+    assert_eq!(threshold, ping_threshold);
+
+    harness.shutdown().await;
+}
+
+/// Verifies the AddrSpammer threshold boundary with addr messages: exactly
+/// `threshold` addrs stay silent; the (threshold + 1)-th fires the alert
+#[tokio::test]
+async fn test_addr_spammer() {
+    let addr_threshold = 2;
+    let mut harness =
+        TestHarness::new(|port| make_test_args(port, 10, 60, addr_threshold, 60, 3600)).await;
+
+    let event = make_addr_event(2, "5.6.7.8:8333");
+    let subject = Subject::NetMsg.to_string();
+
+    publish_n(&harness.publisher, &subject, &event, addr_threshold).await;
+    assert!(
+        expect_no_alert(&mut harness.rx, Duration::from_millis(500)).await,
+        "exactly threshold addrs must not fire an alert"
+    );
+
+    publish_n(&harness.publisher, &subject, &event, 1).await;
+    let alert = recv_alert(&mut harness.rx, Duration::from_secs(2)).await;
+    let (kind, peer_id, count, threshold) = unwrap_spammer(alert);
+    assert_eq!(kind, SpammerKind::Addr);
+    assert_eq!(peer_id, 2);
+    assert_eq!(count, addr_threshold + 1);
+    assert_eq!(threshold, addr_threshold);
+
+    harness.shutdown().await;
+}
+
+/// Same boundary test as `test_addr_spammer` but with addrv2 messages,
+/// verifying both message types share the same counter
+#[tokio::test]
+async fn test_addrv2_spammer() {
+    let addr_threshold = 2;
+    let mut harness =
+        TestHarness::new(|port| make_test_args(port, 10, 60, addr_threshold, 60, 3600)).await;
+
+    let event = make_addrv2_event(3, "9.10.11.12:8333");
+    let subject = Subject::NetMsg.to_string();
+
+    publish_n(&harness.publisher, &subject, &event, addr_threshold).await;
+    assert!(
+        expect_no_alert(&mut harness.rx, Duration::from_millis(500)).await,
+        "exactly threshold addrv2 messages must not fire an alert"
+    );
+
+    publish_n(&harness.publisher, &subject, &event, 1).await;
+    let alert = recv_alert(&mut harness.rx, Duration::from_secs(2)).await;
+    let (kind, peer_id, count, threshold) = unwrap_spammer(alert);
+    assert_eq!(kind, SpammerKind::Addr);
+    assert_eq!(peer_id, 3);
+    assert_eq!(count, addr_threshold + 1);
+    assert_eq!(threshold, addr_threshold);
+
+    harness.shutdown().await;
+}
+
+/// Verifies that outbound pings are silently dropped and never trigger an alert
+#[tokio::test]
+async fn test_ping_spammer_outbound_ignored() {
+    let mut harness = TestHarness::new(|port| make_test_args(port, 3, 60, 5, 60, 3600)).await;
+
+    for _ in 0..4 {
+        harness
+            .publisher
+            .publish(
+                Subject::NetMsg.to_string(),
+                make_ping_event(4, "99.99.99.99:8333", false).encode_to_vec(),
+            )
+            .await;
+    }
+
+    assert!(
+        expect_no_alert(&mut harness.rx, Duration::from_millis(500)).await,
+        "outbound pings must never produce alerts"
+    );
+
+    harness.shutdown().await;
+}
+
+/// Confirms that `run` returns a `NatsConnect` error when no NATS server is reachable
+#[tokio::test]
+async fn test_integration_alerts_fail_if_no_nats() {
+    let (_, shutdown_rx) = watch::channel(false);
+    let (alerter, _rx) = IntegrationTestAlerter::new();
+    let alerts_handle = tokio::spawn(async move {
+        let args = make_test_args(65535, 10, 60, 5, 60, 3600);
+        match alerts::run(args, alerter, shutdown_rx.clone()).await {
+            Ok(_) => panic!("We should fail when no NATS server is reachable."),
+            Err(e) => match e {
+                RuntimeError::NatsConnect(_) => (),
+                _ => panic!("Expected NatsConnect error since the NATS server isn't reachable."),
+            },
+        };
+    });
+
+    alerts_handle.await.unwrap();
+}
+
+/// Exercises the Close path for a non-spammer peer: cleanup happens silently
+/// (no alert), confirming `log_disconnect` is guarded by `first_alerted`
+#[tokio::test]
+async fn test_closed_connection_cleans_state() {
+    // threshold=10 so peer 99 never becomes a spammer
+    let mut harness = TestHarness::new(|port| make_test_args(port, 10, 60, 5, 60, 3600)).await;
+
+    harness
+        .publisher
+        .publish(
+            Subject::NetMsg.to_string(),
+            make_ping_event(99, "1.1.1.1:8333", true).encode_to_vec(),
+        )
+        .await;
+
+    sleep(Duration::from_millis(50)).await;
+
+    harness
+        .publisher
+        .publish(
+            Subject::NetConn.to_string(),
+            make_closed_event(99, "1.1.1.1:8333").encode_to_vec(),
+        )
+        .await;
+
+    // No alerts at all for this peer — neither spammer nor disconnect-of-flagged
+    assert!(
+        expect_no_alert(&mut harness.rx, Duration::from_millis(500)).await,
+        "non-spammer peer closing must not produce any alert"
+    );
+
+    harness.shutdown().await;
+}
+
+/// Verifies one-shot suppression: the alert fires when the threshold is
+/// crossed and stays silent for any further hits on the same peer/kind
+#[tokio::test]
+async fn test_ping_spammer_fires_only_once() {
+    let ping_threshold = 3;
+    let mut harness =
+        TestHarness::new(|port| make_test_args(port, ping_threshold, 60, 5, 60, 3600)).await;
+
+    let event = make_ping_event(10, "20.21.22.23:8333", true);
+    let subject = Subject::NetMsg.to_string();
+
+    publish_n(&harness.publisher, &subject, &event, ping_threshold).await;
+    assert!(
+        expect_no_alert(&mut harness.rx, Duration::from_millis(500)).await,
+        "exactly threshold pings must not fire an alert"
+    );
+
+    publish_n(&harness.publisher, &subject, &event, 1).await;
+    let alert = recv_alert(&mut harness.rx, Duration::from_secs(2)).await;
+    let (kind, peer_id, _, _) = unwrap_spammer(alert);
+    assert_eq!(kind, SpammerKind::Ping);
+    assert_eq!(peer_id, 10);
+
+    // 6 more hits — none should re-alert
+    publish_n(&harness.publisher, &subject, &event, 6).await;
+    assert!(
+        expect_no_alert(&mut harness.rx, Duration::from_millis(500)).await,
+        "one-shot flag must suppress further PingSpammer alerts for the same peer"
+    );
+
+    harness.shutdown().await;
+}
+
+/// Verifies that a flagged peer's Close event emits a `PeerDisconnected`
+/// alert through the `Alerter` channel as spam alerts
+#[tokio::test]
+async fn test_flagged_peer_disconnect_emits_disconnect_alert() {
+    let ping_threshold = 3;
+    let mut harness =
+        TestHarness::new(|port| make_test_args(port, ping_threshold, 60, 5, 60, 3600)).await;
+
+    let event = make_ping_event(50, "50.51.52.53:8333", true);
+    let subject = Subject::NetMsg.to_string();
+
+    publish_n(&harness.publisher, &subject, &event, ping_threshold).await;
+    assert!(
+        expect_no_alert(&mut harness.rx, Duration::from_millis(500)).await,
+        "exactly threshold pings must not fire an alert"
+    );
+
+    publish_n(&harness.publisher, &subject, &event, 1).await;
+    let alert = recv_alert(&mut harness.rx, Duration::from_secs(2)).await;
+    let (kind, peer_id, _, _) = unwrap_spammer(alert);
+    assert_eq!(kind, SpammerKind::Ping);
+    assert_eq!(peer_id, 50);
+
+    harness
+        .publisher
+        .publish(
+            Subject::NetConn.to_string(),
+            make_closed_event(50, "50.51.52.53:8333").encode_to_vec(),
+        )
+        .await;
+
+    // Flagged peer's Close emits a `PeerDisconnected` alert through the same channel
+    let disconnect = recv_alert(&mut harness.rx, Duration::from_secs(2)).await;
+    match disconnect {
+        Alert::PeerDisconnected { peer_id, .. } => assert_eq!(peer_id, 50),
+        other => panic!("expected Alert::PeerDisconnected, got {other:?}"),
+    }
+
+    harness.shutdown().await;
+}
+
+/// Verifies that stale peers are evicted by the cleanup interval, and that
+/// the eviction of a flagged peer emits a `PeerDisconnected` alert
+#[tokio::test]
+async fn test_stale_peer_cleanup_emits_disconnect_alert() {
+    let ping_threshold = 3;
+    // peer_stale_secs=1 so the cleanup tick evicts peer 60 quickly
+    let mut harness =
+        TestHarness::new(|port| make_test_args(port, ping_threshold, 60, 5, 60, 1)).await;
+
+    let event = make_ping_event(60, "60.61.62.63:8333", true);
+    let subject = Subject::NetMsg.to_string();
+
+    publish_n(&harness.publisher, &subject, &event, ping_threshold).await;
+    assert!(
+        expect_no_alert(&mut harness.rx, Duration::from_millis(500)).await,
+        "exactly threshold pings must not fire an alert"
+    );
+
+    publish_n(&harness.publisher, &subject, &event, 1).await;
+    let alert = recv_alert(&mut harness.rx, Duration::from_secs(2)).await;
+    let (kind, peer_id, _, _) = unwrap_spammer(alert);
+    assert_eq!(kind, SpammerKind::Ping);
+    assert_eq!(peer_id, 60);
+
+    // Wait for the cleanup interval to evict peer 60 (interval = peer_stale_secs = 1s)
+    let disconnect = recv_alert(&mut harness.rx, Duration::from_secs(5)).await;
+    match disconnect {
+        Alert::PeerDisconnected { peer_id, .. } => assert_eq!(peer_id, 60),
+        other => panic!("expected Alert::PeerDisconnected, got {other:?}"),
+    }
+
+    harness.shutdown().await;
+}
+
+/// Verifies that a malformed (undecodable) NATS payload does not kill the
+/// run loop: the tool must keep processing subsequent valid events
+#[tokio::test]
+async fn test_undecodable_payload_does_not_kill_tool() {
+    let ping_threshold = 3;
+    let mut harness =
+        TestHarness::new(|port| make_test_args(port, ping_threshold, 60, 5, 60, 3600)).await;
+
+    // Garbage payload first — must be logged and skipped, not propagated
+    harness
+        .publisher
+        .publish(Subject::NetMsg.to_string(), b"not a protobuf".to_vec())
+        .await;
+
+    sleep(Duration::from_millis(100)).await;
+
+    // Then a valid spam burst — alert must still fire, proving the loop survived
+    let event = make_ping_event(77, "7.7.7.7:8333", true);
+    let subject = Subject::NetMsg.to_string();
+
+    publish_n(&harness.publisher, &subject, &event, ping_threshold + 1).await;
+    let alert = recv_alert(&mut harness.rx, Duration::from_secs(2)).await;
+    let (kind, peer_id, _, _) = unwrap_spammer(alert);
+    assert_eq!(kind, SpammerKind::Ping);
+    assert_eq!(peer_id, 77);
+
+    harness.shutdown().await;
+}

--- a/tools/archiver/Cargo.toml
+++ b/tools/archiver/Cargo.toml
@@ -8,6 +8,7 @@ shared = { path = "../../shared" }
 serde = { version = "1", features = ["derive"] }
 toml = "0.8"
 sha2 = "0.10"
+zstd = "0.13"
 
 [features]
 strict = []

--- a/tools/archiver/Cargo.toml
+++ b/tools/archiver/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "archiver"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+shared = { path = "../../shared" }
+
+[features]
+strict = []
+nats_integration_tests = []

--- a/tools/archiver/Cargo.toml
+++ b/tools/archiver/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 
 [dependencies]
 shared = { path = "../../shared" }
+serde = { version = "1", features = ["derive"] }
+toml = "0.8"
+sha2 = "0.10"
 
 [features]
 strict = []

--- a/tools/archiver/Cargo.toml
+++ b/tools/archiver/Cargo.toml
@@ -13,6 +13,7 @@ zstd = "0.13"
 [dev-dependencies]
 sha2 = "0.10"
 toml = "0.8"
+replayer = { path = "../replayer" }
 
 [features]
 # Treat warnings as a build error.

--- a/tools/archiver/Cargo.toml
+++ b/tools/archiver/Cargo.toml
@@ -10,6 +10,12 @@ toml = "0.8"
 sha2 = "0.10"
 zstd = "0.13"
 
+[dev-dependencies]
+sha2 = "0.10"
+toml = "0.8"
+
 [features]
+# Treat warnings as a build error.
 strict = []
+# Run integration tests needing a NATS server.
 nats_integration_tests = []

--- a/tools/archiver/Cargo.toml
+++ b/tools/archiver/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 
 [dependencies]
 shared = { path = "../../shared" }
-serde = { version = "1", features = ["derive"] }
 toml = "0.8"
 sha2 = "0.10"
 zstd = "0.13"

--- a/tools/archiver/Cargo.toml
+++ b/tools/archiver/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 shared = { path = "../../shared" }
+time = { version = "0.3", features = ["formatting", "macros"] }
 toml = "0.8"
 sha2 = "0.10"
 

--- a/tools/archiver/Cargo.toml
+++ b/tools/archiver/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 shared = { path = "../../shared" }
 toml = "0.8"
 sha2 = "0.10"
-zstd = "0.13"
 
 [dev-dependencies]
 sha2 = "0.10"

--- a/tools/archiver/README.md
+++ b/tools/archiver/README.md
@@ -1,0 +1,105 @@
+# `archiver` tool
+
+> archives peer-observer events to disk
+
+A peer-observer tool that subscribes to a NATS server and persists events to binary files on disk.
+By default, all event types are archived. Events can be filtered by type using flags, allowing
+multiple archiver instances to run simultaneously for different recording jobs.
+
+## File format
+
+Events are stored as sequential length-delimited protobuf messages (using `encode_length_delimited`
+from `prost`), preceded by a 16-byte header:
+
+```
+[ 2B magic "PA" ][ 1B version ][ 4B git commit hash ][ 9B reserved ]
+[ varint length ][ protobuf Event bytes ]
+[ varint length ][ protobuf Event bytes ]
+...
+```
+
+The git commit hash in the header identifies the exact version of the protobuf definitions used
+to record the file, allowing future readers to check out that commit if needed.
+
+## Manifest
+
+Each recording session produces a `<base-name>.manifest.toml` file alongside the archive files.
+The manifest is updated on every file rotation and on shutdown. It contains session metadata
+(timestamps, total events, NATS address) and per-file metadata (event count, raw size, SHA-256
+checksum, event types, first/last timestamps).
+
+## Compression
+
+Completed files are compressed with zstd after rotation, in a background task that does not block
+event ingestion. The default compression level is 22 (ultra). Use `--compression-level 3` for
+faster compression (~5x ratio) or `--compression-level 0` to skip compression.
+
+## Example
+
+Archive all events from a NATS server, rotating files at 100 MB, with zstd compression:
+
+```
+$ cargo run -p archiver -- \
+    --nats-address 127.0.0.1:4222 \
+    --output-dir ./archive \
+    --base-name mainnet \
+    --max-file-size 104857600 \
+    --compression-level 22
+```
+
+Archive only P2P messages and mempool events:
+
+```
+$ ./target/release/archiver \
+    --nats-address 127.0.0.1:4222 \
+    --output-dir ./archive \
+    --messages --mempool
+```
+
+## Usage
+
+```
+Archive peer-observer events to disk
+
+Usage: archiver [OPTIONS] --output-dir <OUTPUT_DIR>
+
+Options:
+  -a, --nats-address <ADDRESS>
+          The NATS server address the extractor/tool should connect and subscribe to [default: 127.0.0.1:4222]
+  -u, --nats-username <USERNAME>
+          The NATS username the extractor/tool should try to authentificate to the NATS server with
+  -p, --nats-password <PASSWORD>
+          The NATS password the extractor/tool should try to authentificate to the NATS server with
+  -f, --nats-password-file <PASSWORD_FILE>
+          A path to a file containing a password the extractor/tool should try to authentificate to the NATS server with
+  -o, --output-dir <OUTPUT_DIR>
+          Output directory for archive files
+  -b, --base-name <BASE_NAME>
+          Base name for archive files (e.g., "mainnet" -> "mainnet.0.bin") [default: archive]
+      --max-file-size <MAX_FILE_SIZE>
+          Maximum file size in bytes before rotation (default: 1GB) [default: 1073741824]
+  -l, --log-level <LOG_LEVEL>
+          The log level the tool should run on [default: INFO]
+      --messages
+          If passed, archive P2P message events
+      --connections
+          If passed, archive P2P connection events
+      --addrman
+          If passed, archive addrman events
+      --mempool
+          If passed, archive mempool events
+      --validation
+          If passed, archive validation events
+      --rpc
+          If passed, archive RPC events
+      --p2p-extractor
+          If passed, archive p2p-extractor events
+      --log-extractor
+          If passed, archive log-extractor events
+      --compression-level <COMPRESSION_LEVEL>
+          Zstd compression level (0 = no compression, 3 = default, 22 = ultra) [default: 22]
+  -h, --help
+          Print help
+  -V, --version
+          Print version
+```

--- a/tools/archiver/README.md
+++ b/tools/archiver/README.md
@@ -30,9 +30,10 @@ checksum, event types, first/last timestamps).
 
 ## Compression
 
-Completed files are compressed with zstd after rotation, in a background task that does not block
-event ingestion. The default compression level is 22 (ultra). Use `--compression-level 3` for
-faster compression (~5x ratio) or `--compression-level 0` to skip compression.
+Archive files are compressed with zstd using streaming compression — the writer is wrapped in a
+`zstd::Encoder`, so files are written as `.bin.zst` directly. The default compression level is
+22 (ultra). Use `--compression-level 3` for faster compression (~5x ratio)
+or `--compression-level 0` to skip compression.
 
 ## Example
 
@@ -97,7 +98,7 @@ Options:
       --log-extractor
           If passed, archive log-extractor events
       --compression-level <COMPRESSION_LEVEL>
-          Zstd compression level (0 = no compression, 3 = default, 22 = ultra) [default: 22]
+          Zstd compression level (1-22, 0 = zstd default). Default: 22 (ultra) [default: 22]
   -h, --help
           Print help
   -V, --version

--- a/tools/archiver/README.md
+++ b/tools/archiver/README.md
@@ -25,15 +25,17 @@ to record the file, allowing future readers to check out that commit if needed.
 
 Each recording session produces a `<base-name>.manifest.toml` file alongside the archive files.
 The manifest is updated on every file rotation and on shutdown. It contains session metadata
-(timestamps, total events, NATS address) and per-file metadata (event count, raw size, SHA-256
-checksum, event types, first/last timestamps).
+(timestamps, total events, NATS address) and per-file metadata (event count, uncompressed size,
+SHA-256 checksums, event types, first/last timestamps). When compression is enabled, each file
+entry also includes the compressed file size and checksum.
 
 ## Compression
 
 Archive files are compressed with zstd using streaming compression — the writer is wrapped in a
 `zstd::Encoder`, so files are written as `.bin.zst` directly. The default compression level is
 22 (ultra). Use `--compression-level 3` for faster compression (~5x ratio)
-or `--compression-level 0` to skip compression.
+or `--compression-level 0` to skip compression. Rotation (`--max-file-size`) is checked against
+the compressed output stream. May overshoot slightly due to zstd internal buffering.
 
 ## Example
 
@@ -78,7 +80,7 @@ Options:
   -b, --base-name <BASE_NAME>
           Base name for archive files (e.g., "mainnet" -> "mainnet.0.bin") [default: archive]
       --max-file-size <MAX_FILE_SIZE>
-          Maximum file size in bytes before rotation (default: 1GB) [default: 1073741824]
+          Maximum compressed output size in bytes before rotation (default: 1GB) [default: 1073741824]
   -l, --log-level <LOG_LEVEL>
           The log level the tool should run on [default: INFO]
       --messages

--- a/tools/archiver/README.md
+++ b/tools/archiver/README.md
@@ -23,9 +23,8 @@ to record the file, allowing future readers to check out that commit if needed.
 
 ## Manifest
 
-Each recording session produces a `<base-name>.<timestamp>.manifest.toml` file alongside the
-archive files. The manifest is updated on every file rotation and on shutdown. It contains per-file
-metadata (version, NATS address, event count, uncompressed size, SHA-256 checksum, event types,
+Each archive file has a corresponding `<base-name>.<timestamp>.manifest.toml` with its metadata
+(version, NATS address, event count, uncompressed size, SHA-256 checksum, event types,
 first/last timestamps).
 
 ## Compression
@@ -86,8 +85,6 @@ Options:
           If passed, archive P2P message events
       --connections
           If passed, archive P2P connection events
-      --addrman
-          If passed, archive addrman events
       --mempool
           If passed, archive mempool events
       --validation

--- a/tools/archiver/README.md
+++ b/tools/archiver/README.md
@@ -23,11 +23,10 @@ to record the file, allowing future readers to check out that commit if needed.
 
 ## Manifest
 
-Each recording session produces a `<base-name>.manifest.toml` file alongside the archive files.
-The manifest is updated on every file rotation and on shutdown. It contains session metadata
-(timestamps, total events, NATS address) and per-file metadata (event count, uncompressed size,
-SHA-256 checksums, event types, first/last timestamps). When compression is enabled, each file
-entry also includes the compressed file size and checksum.
+Each recording session produces a `<base-name>.<timestamp>.manifest.toml` file alongside the
+archive files. The manifest is updated on every file rotation and on shutdown. It contains per-file
+metadata (version, NATS address, event count, uncompressed size, SHA-256 checksum, event types,
+first/last timestamps).
 
 ## Compression
 
@@ -78,7 +77,7 @@ Options:
   -o, --output-dir <OUTPUT_DIR>
           Output directory for archive files
   -b, --base-name <BASE_NAME>
-          Base name for archive files (e.g., "mainnet" -> "mainnet.0.bin") [default: archive]
+          Base name for archive files (e.g., "mainnet" -> "mainnet.<timestamp>.bin.zst") [default: archive]
       --max-file-size <MAX_FILE_SIZE>
           Maximum compressed output size in bytes before rotation (default: 1GB) [default: 1073741824]
   -l, --log-level <LOG_LEVEL>

--- a/tools/archiver/README.md
+++ b/tools/archiver/README.md
@@ -100,7 +100,7 @@ Options:
       --log-extractor
           If passed, archive log-extractor events
       --compression-level <COMPRESSION_LEVEL>
-          Zstd compression level (1-22, 0 = zstd default). Default: 22 (ultra) [default: 22]
+          Zstd compression level (0 = no compression, 1-22). Default: 22 (ultra) [default: 22]
   -h, --help
           Print help
   -V, --version

--- a/tools/archiver/build.rs
+++ b/tools/archiver/build.rs
@@ -12,14 +12,15 @@ fn main() {
     let b0 = u8::from_str_radix(&hash[0..2], 16).unwrap();
     let b1 = u8::from_str_radix(&hash[2..4], 16).unwrap();
     let b2 = u8::from_str_radix(&hash[4..6], 16).unwrap();
+    let b3 = u8::from_str_radix(&hash[6..8], 16).unwrap();
 
     let out_dir = std::env::var("OUT_DIR").unwrap();
     let path = std::path::Path::new(&out_dir).join("git_hash.rs");
     std::fs::write(
         path,
         format!(
-            "const GIT_HASH: [u8; 3] = [0x{:02x}, 0x{:02x}, 0x{:02x}];\n",
-            b0, b1, b2
+            "const GIT_HASH: [u8; 4] = [0x{:02x}, 0x{:02x}, 0x{:02x}, 0x{:02x}];\n",
+            b0, b1, b2, b3
         ),
     )
     .unwrap();

--- a/tools/archiver/build.rs
+++ b/tools/archiver/build.rs
@@ -1,13 +1,25 @@
 use std::process::Command;
 
 fn main() {
-    let output = Command::new("git")
-        .args(["rev-parse", "HEAD"])
-        .output()
-        .expect("failed to run git rev-parse HEAD");
-
-    let hash = String::from_utf8(output.stdout).unwrap();
-    let hash = hash.trim();
+    let hash = std::env::var("GIT_HASH")
+        .ok()
+        .filter(|h| h.len() >= 8)
+        .or_else(|| {
+            let output = Command::new("git")
+                .args(["rev-parse", "HEAD"])
+                .output()
+                .ok()?;
+            if !output.status.success() {
+                return None;
+            }
+            let h = String::from_utf8(output.stdout).ok()?.trim().to_string();
+            if h.len() >= 8 {
+                Some(h)
+            } else {
+                None
+            }
+        })
+        .unwrap_or_else(|| "00000000".to_string());
 
     let b0 = u8::from_str_radix(&hash[0..2], 16).unwrap();
     let b1 = u8::from_str_radix(&hash[2..4], 16).unwrap();
@@ -25,5 +37,6 @@ fn main() {
     )
     .unwrap();
 
+    println!("cargo:rerun-if-env-changed=GIT_HASH");
     println!("cargo:rerun-if-changed=../../.git/HEAD");
 }

--- a/tools/archiver/build.rs
+++ b/tools/archiver/build.rs
@@ -1,0 +1,28 @@
+use std::process::Command;
+
+fn main() {
+    let output = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .expect("failed to run git rev-parse HEAD");
+
+    let hash = String::from_utf8(output.stdout).unwrap();
+    let hash = hash.trim();
+
+    let b0 = u8::from_str_radix(&hash[0..2], 16).unwrap();
+    let b1 = u8::from_str_radix(&hash[2..4], 16).unwrap();
+    let b2 = u8::from_str_radix(&hash[4..6], 16).unwrap();
+
+    let out_dir = std::env::var("OUT_DIR").unwrap();
+    let path = std::path::Path::new(&out_dir).join("git_hash.rs");
+    std::fs::write(
+        path,
+        format!(
+            "const GIT_HASH: [u8; 3] = [0x{:02x}, 0x{:02x}, 0x{:02x}];\n",
+            b0, b1, b2
+        ),
+    )
+    .unwrap();
+
+    println!("cargo:rerun-if-changed=../../.git/HEAD");
+}

--- a/tools/archiver/src/error.rs
+++ b/tools/archiver/src/error.rs
@@ -1,0 +1,60 @@
+use shared::async_nats;
+use shared::async_nats::ConnectErrorKind;
+use shared::prost::DecodeError;
+use std::error;
+use std::fmt;
+use std::io;
+
+#[derive(Debug)]
+pub enum RuntimeError {
+    ProtobufDecode(DecodeError),
+    NatsSubscribe(async_nats::client::SubscribeError),
+    NatsConnect(shared::async_nats::error::Error<ConnectErrorKind>),
+    Io(io::Error),
+}
+
+impl fmt::Display for RuntimeError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            RuntimeError::ProtobufDecode(e) => write!(f, "protobuf decode error {}", e),
+            RuntimeError::NatsSubscribe(e) => write!(f, "NATS subscribe error {}", e),
+            RuntimeError::NatsConnect(e) => write!(f, "NATS connection error {}", e),
+            RuntimeError::Io(e) => write!(f, "IO error {}", e),
+        }
+    }
+}
+
+impl error::Error for RuntimeError {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match *self {
+            RuntimeError::ProtobufDecode(ref e) => Some(e),
+            RuntimeError::NatsSubscribe(ref e) => Some(e),
+            RuntimeError::NatsConnect(ref e) => Some(e),
+            RuntimeError::Io(ref e) => Some(e),
+        }
+    }
+}
+
+impl From<DecodeError> for RuntimeError {
+    fn from(e: DecodeError) -> Self {
+        RuntimeError::ProtobufDecode(e)
+    }
+}
+
+impl From<async_nats::client::SubscribeError> for RuntimeError {
+    fn from(e: async_nats::client::SubscribeError) -> Self {
+        RuntimeError::NatsSubscribe(e)
+    }
+}
+
+impl From<shared::async_nats::error::Error<ConnectErrorKind>> for RuntimeError {
+    fn from(e: shared::async_nats::error::Error<ConnectErrorKind>) -> Self {
+        RuntimeError::NatsConnect(e)
+    }
+}
+
+impl From<io::Error> for RuntimeError {
+    fn from(e: io::Error) -> Self {
+        RuntimeError::Io(e)
+    }
+}

--- a/tools/archiver/src/lib.rs
+++ b/tools/archiver/src/lib.rs
@@ -8,6 +8,9 @@ use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use time::macros::format_description;
+use time::OffsetDateTime;
+
 use sha2::{Digest, Sha256};
 use shared::serde::Serialize;
 
@@ -206,11 +209,13 @@ impl ArchiveFile {
         };
         // Retry on rare timestamp collisions (e.g. fast rotations in tests)
         let (path, file) = loop {
-            let ts = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap()
-                .as_millis() as u64;
-            let path = output_dir.join(format!("{}.{}.{}", base_name, ts, ext));
+            let timestamp = format_utc_timestamp(
+                SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap()
+                    .as_millis() as u64,
+            );
+            let path = output_dir.join(format!("{}.{}.{}", base_name, timestamp, ext));
             match fs::OpenOptions::new()
                 .write(true)
                 .create_new(true)
@@ -224,7 +229,7 @@ impl ArchiveFile {
                     return Err(std::io::Error::new(
                         e.kind(),
                         format!("failed to create archive {}: {}", path.display(), e),
-                    ))
+                    ));
                 }
             }
         };
@@ -516,10 +521,19 @@ fn write_manifest(session: &SessionState, args: &Args) -> std::io::Result<()> {
     };
     let manifest_path = args.output_dir.join(format!(
         "{}.{}.manifest.toml",
-        args.base_name, session.started_at_ms
+        args.base_name,
+        format_utc_timestamp(session.started_at_ms)
     ));
     let toml_str = toml::to_string_pretty(&manifest).map_err(std::io::Error::other)?;
     fs::write(&manifest_path, &toml_str)?;
     log::info!("wrote manifest: {}", manifest_path.display());
     Ok(())
+}
+
+fn format_utc_timestamp(epoch_ms: u64) -> String {
+    let fmt = format_description!("[year][month][day]-[hour][minute][second]-[subsecond digits:3]");
+    OffsetDateTime::from_unix_timestamp_nanos(epoch_ms as i128 * 1_000_000)
+        .expect("timestamp out of range")
+        .format(&fmt)
+        .expect("timestamp formatting failed")
 }

--- a/tools/archiver/src/lib.rs
+++ b/tools/archiver/src/lib.rs
@@ -329,10 +329,6 @@ pub struct Args {
     #[arg(long)]
     pub connections: bool,
 
-    /// If passed, archive addrman events.
-    #[arg(long)]
-    pub addrman: bool,
-
     /// If passed, archive mempool events.
     #[arg(long)]
     pub mempool: bool,
@@ -363,7 +359,6 @@ impl Args {
     pub fn compress_all(&self) -> bool {
         !(self.messages
             || self.connections
-            || self.addrman
             || self.mempool
             || self.validation
             || self.rpc
@@ -379,7 +374,6 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
         log::info!("archiving all events:           {}", args.compress_all());
         log::info!("archiving P2P messages:         {}", args.messages);
         log::info!("archiving P2P connections:      {}", args.connections);
-        log::info!("archiving addrman events:       {}", args.addrman);
         log::info!("archiving mempool events:       {}", args.mempool);
         log::info!("archiving validation events:    {}", args.validation);
         log::info!("archiving rpc events:           {}", args.rpc);
@@ -489,7 +483,6 @@ fn should_archive(event: &Event, args: &Args) -> bool {
     match event_type_name(event) {
         Some("messages") => args.messages,
         Some("connections") => args.connections,
-        Some("addrman") => args.addrman,
         Some("mempool") => args.mempool,
         Some("validation") => args.validation,
         Some("rpc") => args.rpc,
@@ -504,7 +497,6 @@ fn event_type_name(event: &Event) -> Option<&'static str> {
         PeerObserverEvent::EbpfExtractor(e) => match e.ebpf_event.as_ref()? {
             ebpf::EbpfEvent::Message(_) => "messages",
             ebpf::EbpfEvent::Connection(_) => "connections",
-            ebpf::EbpfEvent::Addrman(_) => "addrman",
             ebpf::EbpfEvent::Mempool(_) => "mempool",
             ebpf::EbpfEvent::Validation(_) => "validation",
         },

--- a/tools/archiver/src/lib.rs
+++ b/tools/archiver/src/lib.rs
@@ -2,6 +2,15 @@ mod error;
 
 pub use error::RuntimeError;
 
+use std::collections::HashSet;
+use std::fs::{self, File};
+use std::io::{BufWriter, Write};
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+
 use shared::clap;
 use shared::clap::Parser;
 use shared::futures::stream::StreamExt;
@@ -12,18 +21,6 @@ use shared::protobuf::ebpf_extractor::ebpf;
 use shared::protobuf::event::event::PeerObserverEvent;
 use shared::protobuf::event::Event;
 use shared::tokio::sync::watch;
-use shared::tokio::task::JoinHandle;
-use std::path::PathBuf;
-
-use std::collections::HashSet;
-use std::fs::{self, File};
-use std::io::{BufReader, BufWriter, Write};
-use std::time::{SystemTime, UNIX_EPOCH};
-
-use serde::Serialize;
-use sha2::{Digest, Sha256};
-
-type CompressionResult = std::io::Result<(u64, usize)>;
 
 const MAGIC: [u8; 2] = *b"PA";
 const VERSION: u8 = 1;
@@ -33,17 +30,17 @@ include!(concat!(env!("OUT_DIR"), "/git_hash.rs"));
 struct ArchiveHeader {
     magic: [u8; 2],
     version: u8,
-    git_hash: [u8; 3],
-    reserved: [u8; 10],
+    git_hash: [u8; 4],
+    reserved: [u8; 9],
 }
 
 impl ArchiveHeader {
-    fn new(git_hash: [u8; 3]) -> Self {
+    fn new(git_hash: [u8; 4]) -> Self {
         Self {
             magic: MAGIC,
             version: VERSION,
             git_hash,
-            reserved: [0u8; 10],
+            reserved: [0u8; 9],
         }
     }
 
@@ -51,8 +48,8 @@ impl ArchiveHeader {
         let mut buf = [0u8; HEADER_SIZE];
         buf[0..2].copy_from_slice(&self.magic);
         buf[2] = self.version;
-        buf[3..6].copy_from_slice(&self.git_hash);
-        buf[6..16].copy_from_slice(&self.reserved);
+        buf[3..7].copy_from_slice(&self.git_hash);
+        buf[7..16].copy_from_slice(&self.reserved);
         buf
     }
 }
@@ -82,7 +79,158 @@ struct FileEntry {
     last_timestamp: u64,
     event_types: Vec<String>,
     checksum: String,
-    compressed_size: u64,
+}
+
+/// Holds session-level state that persists across file rotations.
+struct SessionState {
+    created_at: u64,
+    file_index: u32,
+    manifest_files: Vec<FileEntry>,
+}
+
+impl SessionState {
+    fn new() -> Self {
+        Self {
+            created_at: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_millis() as u64,
+            file_index: 0,
+            manifest_files: Vec::new(),
+        }
+    }
+}
+
+enum ArchiveWriter {
+    Plain(BufWriter<File>),
+    Zstd(zstd::Encoder<'static, BufWriter<File>>),
+}
+
+impl ArchiveWriter {
+    fn new(file: File, compression_level: i32) -> std::io::Result<Self> {
+        if compression_level > 0 {
+            Ok(Self::Zstd(zstd::Encoder::new(
+                BufWriter::new(file),
+                compression_level,
+            )?))
+        } else {
+            Ok(Self::Plain(BufWriter::new(file)))
+        }
+    }
+
+    fn finish(self) -> std::io::Result<()> {
+        match self {
+            Self::Plain(mut writer) => writer.flush(),
+            Self::Zstd(encoder) => {
+                let mut inner = encoder.finish()?;
+                inner.flush()?;
+                Ok(())
+            }
+        }
+    }
+}
+
+impl Write for ArchiveWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        match self {
+            Self::Plain(writer) => writer.write(buf),
+            Self::Zstd(encoder) => encoder.write(buf),
+        }
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        match self {
+            Self::Plain(writer) => writer.flush(),
+            Self::Zstd(encoder) => encoder.flush(),
+        }
+    }
+}
+
+/// Holds all mutable state for the currently open archive file.
+/// Tracks bytes written, event counts, timestamps, and event types
+/// so that the main event loop only needs to call write_event() and
+/// check needs_rotation().
+struct ArchiveFile {
+    path: PathBuf,
+    writer: ArchiveWriter,
+    hasher: Sha256,
+    bytes_written: u64,
+    events: u64,
+    first_timestamp: u64,
+    last_timestamp: u64,
+    event_types: HashSet<&'static str>,
+}
+
+impl ArchiveFile {
+    fn new(
+        output_dir: &Path,
+        base_name: &str,
+        index: u32,
+        compression_level: i32,
+    ) -> std::io::Result<Self> {
+        let ext = if compression_level > 0 {
+            "bin.zst"
+        } else {
+            "bin"
+        };
+        let path = output_dir.join(format!("{}.{}.{}", base_name, index, ext));
+        let file = File::create(&path)?;
+        let mut writer = ArchiveWriter::new(file, compression_level)?;
+        let mut hasher = Sha256::new();
+        // header: 16 bytes = MAGIC "PA" (2B) + VERSION (1B) + GIT_HASH (4B) + reserved (9B)
+        let header_bytes = ArchiveHeader::new(GIT_HASH).to_bytes();
+        writer.write_all(&header_bytes)?;
+        hasher.update(header_bytes);
+        writer.flush()?;
+        Ok(Self {
+            path,
+            writer,
+            hasher,
+            bytes_written: HEADER_SIZE as u64,
+            events: 0,
+            first_timestamp: 0,
+            last_timestamp: 0,
+            event_types: HashSet::new(),
+        })
+    }
+
+    fn write_event(&mut self, event: &Event) -> std::io::Result<()> {
+        let buf = event.encode_length_delimited_to_vec();
+        self.writer.write_all(&buf)?;
+        self.hasher.update(&buf);
+        self.bytes_written += buf.len() as u64;
+        self.events += 1;
+        if self.first_timestamp == 0 {
+            self.first_timestamp = event.timestamp;
+        }
+        self.last_timestamp = event.timestamp;
+        if let Some(name) = event_type_name(event) {
+            self.event_types.insert(name);
+        }
+        Ok(())
+    }
+
+    fn needs_rotation(&self, max_file_size: u64) -> bool {
+        self.bytes_written >= max_file_size
+    }
+
+    fn finalize(self, name: String) -> std::io::Result<(PathBuf, FileEntry)> {
+        self.writer.finish()?;
+        let checksum = format!("{:x}", self.hasher.finalize());
+        let mut sorted_types: Vec<String> =
+            self.event_types.into_iter().map(String::from).collect();
+        sorted_types.sort();
+        let entry = FileEntry {
+            name,
+            size_bytes: self.bytes_written,
+            events: self.events,
+            first_timestamp: self.first_timestamp,
+            last_timestamp: self.last_timestamp,
+            event_types: sorted_types,
+            checksum,
+        };
+        Ok((self.path, entry))
+    }
 }
 
 #[derive(Parser, Debug, Clone)]
@@ -100,7 +248,7 @@ pub struct Args {
     #[arg(short, long, default_value = "archive")]
     pub base_name: String,
 
-    /// Maximum file size in bytes before rotation (default: 1GB).
+    /// Maximum uncompressed file size in bytes before rotation (default: 1GB).
     #[arg(long, default_value_t = 1_073_741_824)]
     pub max_file_size: u64,
 
@@ -140,7 +288,7 @@ pub struct Args {
     #[arg(long)]
     pub log_extractor: bool,
 
-    /// Zstd compression level (0 = no compression, 3 = default, 22 = ultra).
+    /// Zstd compression level (0 = no compression, 1-22). Default: 22 (ultra).
     #[arg(long, default_value_t = 22)]
     pub compression_level: i32,
 }
@@ -181,103 +329,32 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
     let mut sub = nc.subscribe("*").await?;
     log::info!("Connected to NATS-server at {}", args.nats.address);
 
-    let created_at = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_millis() as u64;
-
     fs::create_dir_all(&args.output_dir)?;
-    let mut file_index: u32 = 0;
-    let mut bytes_written: u64 = 16; // header
-    let (mut file_path, mut writer, mut hasher) =
-        create_archive_file(&args.output_dir, &args.base_name, file_index)?;
-    log::info!("Created archive file: {}", file_path.display());
-
-    let mut event_count: u64 = 0;
-    let mut file_events: u64 = 0;
-    let mut first_timestamp: u64 = 0;
-    let mut last_timestamp: u64 = 0;
-    let mut event_types: HashSet<String> = HashSet::new();
-    let mut manifest_files: Vec<FileEntry> = Vec::new();
-    let mut compression_handle: Option<JoinHandle<CompressionResult>> = None;
+    let mut session = SessionState::new();
+    let mut current_file = ArchiveFile::new(
+        &args.output_dir,
+        &args.base_name,
+        session.file_index,
+        args.compression_level,
+    )?;
+    log::info!("Created archive file: {}", current_file.path.display());
 
     loop {
         shared::tokio::select! {
             maybe_msg = sub.next() => {
-
                 if let Some(msg) = maybe_msg {
-                    let event = Event::decode(msg.payload.as_ref())?;
-                    if should_archive(&event, &args){
-                        let event_bytes = write_event(&mut writer, &event, &mut hasher)?;
-                        bytes_written += event_bytes as u64;
-                        event_count += 1;
-                        file_events += 1;
-
-                        if first_timestamp == 0 {
-                            first_timestamp = event.timestamp;
+                    let event = match Event::decode(msg.payload.as_ref()) {
+                        Ok(event) => event,
+                        Err(e) => {
+                            log::warn!("failed to decode event: {}, skipping", e);
+                            continue;
                         }
-                        last_timestamp = event.timestamp;
-                        event_types.insert(event_type_name(&event));
+                    };
+                    if should_archive(&event, &args){
+                        current_file.write_event(&event)?;
 
-                        if bytes_written >= args.max_file_size {
-                            writer.flush()?;
-                            log::info!("file rotation: {} reached {:.2} MB", file_path.display(), bytes_written as f64 / 1_048_576.0);
-                            let checksum = format!("{:x}", hasher.finalize());
-                            let mut sorted_types: Vec<String> = event_types.drain().collect();
-                            sorted_types.sort();
-                            if let Some(handle) = compression_handle.take() {
-                                let (prev_compressed, prev_index) = handle.await.unwrap()?;
-                                manifest_files[prev_index].compressed_size = prev_compressed;
-                            }
-
-                            let ext = if args.compression_level > 0 { "bin.zst" } else { "bin" };
-                            manifest_files.push(FileEntry {
-                                name: format!("{}.{}.{}", args.base_name, file_index, ext),
-                                size_bytes: bytes_written,
-                                events: file_events,
-                                first_timestamp,
-                                last_timestamp,
-                                event_types: sorted_types,
-                                checksum,
-                                compressed_size: 0,
-                            });
-
-                            write_manifest(
-                                &args.output_dir,
-                                &args.base_name,
-                                &args.nats.address,
-                                created_at,
-                                event_count,
-                                &manifest_files,
-                            )?;
-
-                            if args.compression_level > 0 {
-                                let old_path = file_path.clone();
-                                let old_bytes = bytes_written;
-                                let current_index = manifest_files.len() - 1;
-                                let level = args.compression_level;
-                                compression_handle = Some(shared::tokio::task::spawn_blocking(move || {
-                                    let compressed_size = compress_archive_file(&old_path, level)?;
-                                    log::info!("compressed {:.2} MB -> {:.2} MB (ratio: {:.1}x)",
-                                        old_bytes as f64 / 1_048_576.0,
-                                        compressed_size as f64 / 1_048_576.0,
-                                        old_bytes as f64 / compressed_size as f64);
-                                    Ok((compressed_size, current_index))
-                                }));
-                            } else {
-                                log::info!("wrote {:.2} MB (no compression)", bytes_written as f64 / 1_048_576.0);
-                            }
-
-                            file_index += 1;
-                            bytes_written = 16;
-                            file_events = 0;
-                            first_timestamp = 0;
-                            last_timestamp = 0;
-                            let (new_path, new_writer, new_hasher) = create_archive_file(&args.output_dir, &args.base_name, file_index)?;
-                            file_path = new_path;
-                            writer = new_writer;
-                            hasher = new_hasher;
-                            log::info!("Created archive file: {}", file_path.display());
+                        if current_file.needs_rotation(args.max_file_size) {
+                            current_file = rotate(current_file, &mut session, &args)?;
                         }
                     }
                 } else {
@@ -302,102 +379,87 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
         }
     }
 
-    if let Some(handle) = compression_handle.take() {
-        let (prev_compressed, prev_index) = handle.await.unwrap()?;
-        manifest_files[prev_index].compressed_size = prev_compressed;
-    }
-
-    writer.flush()?;
-    let checksum = format!("{:x}", hasher.finalize());
-    let mut sorted_types: Vec<String> = event_types.drain().collect();
-    sorted_types.sort();
-
-    let (last_compressed, ext) = if args.compression_level > 0 {
-        let compressed = compress_archive_file(&file_path, args.compression_level)?;
-        log::info!(
-            "compressed {:.2} MB -> {:.2} MB (ratio: {:.1}x)",
-            bytes_written as f64 / 1_048_576.0,
-            compressed as f64 / 1_048_576.0,
-            bytes_written as f64 / compressed as f64
-        );
-        (compressed, "bin.zst")
-    } else {
-        log::info!(
-            "wrote {:.2} MB (no compression)",
-            bytes_written as f64 / 1_048_576.0
-        );
-        (0, "bin")
-    };
-
-    manifest_files.push(FileEntry {
-        name: format!("{}.{}.{}", args.base_name, file_index, ext),
-        size_bytes: bytes_written,
-        events: file_events,
-        first_timestamp,
-        last_timestamp,
-        event_types: sorted_types,
-        checksum,
-        compressed_size: last_compressed,
-    });
-
-    write_manifest(
-        &args.output_dir,
-        &args.base_name,
-        &args.nats.address,
-        created_at,
-        event_count,
-        &manifest_files,
-    )?;
+    let total_files = session.file_index + 1;
+    close_file(current_file, &mut session, &args)?;
+    let total_events: u64 = session.manifest_files.iter().map(|f| f.events).sum();
 
     log::info!(
         "shutting down. total events archived: {}, files: {}",
-        event_count,
-        file_index + 1
+        total_events,
+        total_files
     );
     Ok(())
+}
+
+/// Finalizes the current archive file, adds its FileEntry to the manifest,
+/// and writes the manifest to disk.
+fn close_file(
+    current_file: ArchiveFile,
+    session: &mut SessionState,
+    args: &Args,
+) -> std::io::Result<()> {
+    let ext = if args.compression_level > 0 {
+        "bin.zst"
+    } else {
+        "bin"
+    };
+    let name = format!("{}.{}.{}", args.base_name, session.file_index, ext);
+    let (_path, entry) = current_file.finalize(name)?;
+    session.manifest_files.push(entry);
+
+    write_manifest(session, args)
+}
+
+/// Closes the current archive file and opens the next one.
+fn rotate(
+    current_file: ArchiveFile,
+    session: &mut SessionState,
+    args: &Args,
+) -> std::io::Result<ArchiveFile> {
+    close_file(current_file, session, args)?;
+    session.file_index += 1;
+    ArchiveFile::new(
+        &args.output_dir,
+        &args.base_name,
+        session.file_index,
+        args.compression_level,
+    )
 }
 
 fn should_archive(event: &Event, args: &Args) -> bool {
     if args.show_all() {
         return true;
     }
-    match event.peer_observer_event.as_ref().unwrap() {
-        PeerObserverEvent::EbpfExtractor(ebpf) => match ebpf.ebpf_event.as_ref().unwrap() {
-            ebpf::EbpfEvent::Message(_) => args.messages,
-            ebpf::EbpfEvent::Connection(_) => args.connections,
-            ebpf::EbpfEvent::Addrman(_) => args.addrman,
-            ebpf::EbpfEvent::Mempool(_) => args.mempool,
-            ebpf::EbpfEvent::Validation(_) => args.validation,
-        },
-        PeerObserverEvent::RpcExtractor(_) => args.rpc,
-        PeerObserverEvent::P2pExtractor(_) => args.p2p_extractor,
-        PeerObserverEvent::LogExtractor(_) => args.log_extractor,
+    match event_type_name(event) {
+        Some("messages") => args.messages,
+        Some("connections") => args.connections,
+        Some("addrman") => args.addrman,
+        Some("mempool") => args.mempool,
+        Some("validation") => args.validation,
+        Some("rpc") => args.rpc,
+        Some("p2p_extractor") => args.p2p_extractor,
+        Some("log_extractor") => args.log_extractor,
+        _ => false,
     }
 }
 
-fn event_type_name(event: &Event) -> String {
-    match event.peer_observer_event.as_ref().unwrap() {
-        PeerObserverEvent::EbpfExtractor(e) => match e.ebpf_event.as_ref().unwrap() {
-            ebpf::EbpfEvent::Message(_) => "messages".to_string(),
-            ebpf::EbpfEvent::Connection(_) => "connections".to_string(),
-            ebpf::EbpfEvent::Addrman(_) => "addrman".to_string(),
-            ebpf::EbpfEvent::Mempool(_) => "mempool".to_string(),
-            ebpf::EbpfEvent::Validation(_) => "validation".to_string(),
+fn event_type_name(event: &Event) -> Option<&'static str> {
+    let name = match event.peer_observer_event.as_ref()? {
+        PeerObserverEvent::EbpfExtractor(e) => match e.ebpf_event.as_ref()? {
+            ebpf::EbpfEvent::Message(_) => "messages",
+            ebpf::EbpfEvent::Connection(_) => "connections",
+            ebpf::EbpfEvent::Addrman(_) => "addrman",
+            ebpf::EbpfEvent::Mempool(_) => "mempool",
+            ebpf::EbpfEvent::Validation(_) => "validation",
         },
-        PeerObserverEvent::RpcExtractor(_) => "rpc".to_string(),
-        PeerObserverEvent::P2pExtractor(_) => "p2p_extractor".to_string(),
-        PeerObserverEvent::LogExtractor(_) => "log_extractor".to_string(),
-    }
+        PeerObserverEvent::RpcExtractor(_) => "rpc",
+        PeerObserverEvent::P2pExtractor(_) => "p2p_extractor",
+        PeerObserverEvent::LogExtractor(_) => "log_extractor",
+    };
+    Some(name)
 }
 
-fn write_manifest(
-    output_dir: &PathBuf,
-    base_name: &str,
-    nats_address: &str,
-    created_at: u64,
-    event_count: u64,
-    files: &[FileEntry],
-) -> std::io::Result<()> {
+fn write_manifest(session: &SessionState, args: &Args) -> std::io::Result<()> {
     let finished_at = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap()
@@ -405,64 +467,19 @@ fn write_manifest(
     let manifest = Manifest {
         session: Session {
             version: VERSION,
-            nats_address: nats_address.to_string(),
-            created_at,
+            nats_address: args.nats.address.clone(),
+            created_at: session.created_at,
             finished_at,
-            total_events: event_count,
-            total_files: files.len() as u32,
+            total_events: session.manifest_files.iter().map(|file| file.events).sum(),
+            total_files: session.manifest_files.len() as u32,
         },
-        files,
+        files: &session.manifest_files,
     };
-    let manifest_path = output_dir.join(format!("{}.manifest.toml", base_name));
-    let toml_str = toml::to_string_pretty(&manifest)
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+    let manifest_path = args
+        .output_dir
+        .join(format!("{}.manifest.toml", args.base_name));
+    let toml_str = toml::to_string_pretty(&manifest).map_err(std::io::Error::other)?;
     fs::write(&manifest_path, &toml_str)?;
     log::info!("wrote manifest: {}", manifest_path.display());
     Ok(())
-}
-
-fn write_event(
-    writer: &mut BufWriter<File>,
-    event: &Event,
-    hasher: &mut Sha256,
-) -> std::io::Result<usize> {
-    let buf = event.encode_length_delimited_to_vec();
-    writer.write_all(&buf)?;
-    hasher.update(&buf);
-    Ok(buf.len())
-}
-
-// header: 16 bytes = MAGIC "PA" (2B) + VERSION (1B) + GIT_HASH (3B) + reserved (10B)
-fn write_header(writer: &mut BufWriter<File>, hasher: &mut Sha256) -> std::io::Result<()> {
-    let header = ArchiveHeader::new(GIT_HASH);
-    let bytes = header.to_bytes();
-    writer.write_all(&bytes)?;
-    hasher.update(&bytes);
-    writer.flush()?;
-    Ok(())
-}
-
-fn create_archive_file(
-    output_dir: &PathBuf,
-    base_name: &str,
-    index: u32,
-) -> std::io::Result<(PathBuf, BufWriter<File>, Sha256)> {
-    let file_path = output_dir.join(format!("{}.{}.bin", base_name, index));
-    let file = File::create(&file_path)?;
-    let mut writer = BufWriter::new(file);
-    let mut hasher = Sha256::new();
-    write_header(&mut writer, &mut hasher)?;
-    Ok((file_path, writer, hasher))
-}
-
-fn compress_archive_file(path: &PathBuf, level: i32) -> std::io::Result<u64> {
-    let compressed_path = path.with_extension("bin.zst");
-    let input = File::open(path)?;
-    let output = File::create(&compressed_path)?;
-    let mut encoder = zstd::Encoder::new(output, level)?;
-    std::io::copy(&mut BufReader::new(input), &mut encoder)?;
-    encoder.finish()?;
-    let compressed_size = fs::metadata(&compressed_path)?.len();
-    fs::remove_file(path)?;
-    Ok(compressed_size)
 }

--- a/tools/archiver/src/lib.rs
+++ b/tools/archiver/src/lib.rs
@@ -8,8 +8,8 @@ use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use serde::Serialize;
 use sha2::{Digest, Sha256};
+use shared::serde::Serialize;
 
 use shared::clap;
 use shared::clap::Parser;
@@ -55,12 +55,14 @@ impl ArchiveHeader {
 }
 
 #[derive(Serialize)]
+#[serde(crate = "shared::serde")]
 struct Manifest<'a> {
     session: Session,
     files: &'a [FileEntry],
 }
 
 #[derive(Serialize)]
+#[serde(crate = "shared::serde")]
 struct Session {
     version: u8,
     nats_address: String,
@@ -71,6 +73,7 @@ struct Session {
 }
 
 #[derive(Serialize)]
+#[serde(crate = "shared::serde")]
 struct FileEntry {
     name: String,
     size_bytes: u64,
@@ -135,17 +138,14 @@ enum ArchiveWriter {
 }
 
 impl ArchiveWriter {
-    fn new(file: File, compression_level: i32) -> std::io::Result<Self> {
-        if compression_level < 0 {
-            return Err(std::io::Error::other("compression_level must be >= 0"));
-        }
+    fn new(file: File, compression_level: u32) -> std::io::Result<Self> {
         if compression_level > 0 {
             let tracker = TrackingWriter {
                 inner: BufWriter::new(file),
                 hasher: Sha256::new(),
                 bytes_written: 0,
             };
-            let encoder = zstd::Encoder::new(tracker, compression_level)?;
+            let encoder = zstd::Encoder::new(tracker, compression_level as i32)?;
             Ok(Self::Zstd(encoder))
         } else {
             Ok(Self::Plain(BufWriter::new(file)))
@@ -213,7 +213,7 @@ impl ArchiveFile {
         output_dir: &Path,
         base_name: &str,
         index: u32,
-        compression_level: i32,
+        compression_level: u32,
     ) -> std::io::Result<Self> {
         let ext = if compression_level > 0 {
             "bin.zst"
@@ -342,7 +342,7 @@ pub struct Args {
 
     /// Zstd compression level (0 = no compression, 1-22). Default: 22 (ultra).
     #[arg(long, default_value_t = 22)]
-    pub compression_level: i32,
+    pub compression_level: u32,
 }
 
 impl Args {

--- a/tools/archiver/src/lib.rs
+++ b/tools/archiver/src/lib.rs
@@ -12,15 +12,18 @@ use shared::protobuf::ebpf_extractor::ebpf;
 use shared::protobuf::event::event::PeerObserverEvent;
 use shared::protobuf::event::Event;
 use shared::tokio::sync::watch;
+use shared::tokio::task::JoinHandle;
 use std::path::PathBuf;
 
 use std::collections::HashSet;
 use std::fs::{self, File};
-use std::io::{BufWriter, Write};
+use std::io::{BufReader, BufWriter, Write};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::Serialize;
 use sha2::{Digest, Sha256};
+
+type CompressionResult = std::io::Result<(u64, usize)>;
 
 const MAGIC: &[u8; 8] = b"POBS_ARC";
 const VERSION: u8 = 1;
@@ -50,6 +53,7 @@ struct FileEntry {
     last_timestamp: u64,
     event_types: Vec<String>,
     checksum: String,
+    compressed_size: u64,
 }
 
 #[derive(Parser, Debug, Clone)]
@@ -106,6 +110,10 @@ pub struct Args {
     /// If passed, archive log-extractor events.
     #[arg(long)]
     pub log_extractor: bool,
+
+    /// Zstd compression level (0 = no compression, 3 = default, 22 = ultra).
+    #[arg(long, default_value_t = 22)]
+    pub compression_level: i32,
 }
 
 impl Args {
@@ -162,6 +170,7 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
     let mut last_timestamp: u64 = 0;
     let mut event_types: HashSet<String> = HashSet::new();
     let mut manifest_files: Vec<FileEntry> = Vec::new();
+    let mut compression_handle: Option<JoinHandle<CompressionResult>> = None;
 
     loop {
         shared::tokio::select! {
@@ -187,15 +196,21 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
                             let checksum = format!("{:x}", hasher.finalize());
                             let mut sorted_types: Vec<String> = event_types.drain().collect();
                             sorted_types.sort();
+                            if let Some(handle) = compression_handle.take() {
+                                let (prev_compressed, prev_index) = handle.await.unwrap()?;
+                                manifest_files[prev_index].compressed_size = prev_compressed;
+                            }
 
+                            let ext = if args.compression_level > 0 { "bin.zst" } else { "bin" };
                             manifest_files.push(FileEntry {
-                                name: format!("{}.{}.bin", args.base_name, file_index),
+                                name: format!("{}.{}.{}", args.base_name, file_index, ext),
                                 size_bytes: bytes_written,
                                 events: file_events,
                                 first_timestamp,
                                 last_timestamp,
                                 event_types: sorted_types,
                                 checksum,
+                                compressed_size: 0,
                             });
 
                             write_manifest(
@@ -206,6 +221,23 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
                                 event_count,
                                 &manifest_files,
                             )?;
+
+                            if args.compression_level > 0 {
+                                let old_path = file_path.clone();
+                                let old_bytes = bytes_written;
+                                let current_index = manifest_files.len() - 1;
+                                let level = args.compression_level;
+                                compression_handle = Some(shared::tokio::task::spawn_blocking(move || {
+                                    let compressed_size = compress_archive_file(&old_path, level)?;
+                                    log::info!("compressed {:.2} MB -> {:.2} MB (ratio: {:.1}x)",
+                                        old_bytes as f64 / 1_048_576.0,
+                                        compressed_size as f64 / 1_048_576.0,
+                                        old_bytes as f64 / compressed_size as f64);
+                                    Ok((compressed_size, current_index))
+                                }));
+                            } else {
+                                log::info!("wrote {:.2} MB (no compression)", bytes_written as f64 / 1_048_576.0);
+                            }
 
                             file_index += 1;
                             bytes_written = 16;
@@ -241,19 +273,42 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
         }
     }
 
+    if let Some(handle) = compression_handle.take() {
+        let (prev_compressed, prev_index) = handle.await.unwrap()?;
+        manifest_files[prev_index].compressed_size = prev_compressed;
+    }
+
     writer.flush()?;
     let checksum = format!("{:x}", hasher.finalize());
     let mut sorted_types: Vec<String> = event_types.drain().collect();
     sorted_types.sort();
 
+    let (last_compressed, ext) = if args.compression_level > 0 {
+        let compressed = compress_archive_file(&file_path, args.compression_level)?;
+        log::info!(
+            "compressed {:.2} MB -> {:.2} MB (ratio: {:.1}x)",
+            bytes_written as f64 / 1_048_576.0,
+            compressed as f64 / 1_048_576.0,
+            bytes_written as f64 / compressed as f64
+        );
+        (compressed, "bin.zst")
+    } else {
+        log::info!(
+            "wrote {:.2} MB (no compression)",
+            bytes_written as f64 / 1_048_576.0
+        );
+        (0, "bin")
+    };
+
     manifest_files.push(FileEntry {
-        name: format!("{}.{}.bin", args.base_name, file_index),
+        name: format!("{}.{}.{}", args.base_name, file_index, ext),
         size_bytes: bytes_written,
         events: file_events,
         first_timestamp,
         last_timestamp,
         event_types: sorted_types,
         checksum,
+        compressed_size: last_compressed,
     });
 
     write_manifest(
@@ -370,4 +425,16 @@ fn create_archive_file(
     let mut hasher = Sha256::new();
     write_header(&mut writer, &mut hasher)?;
     Ok((file_path, writer, hasher))
+}
+
+fn compress_archive_file(path: &PathBuf, level: i32) -> std::io::Result<u64> {
+    let compressed_path = path.with_extension("bin.zst");
+    let input = File::open(path)?;
+    let output = File::create(&compressed_path)?;
+    let mut encoder = zstd::Encoder::new(output, level)?;
+    std::io::copy(&mut BufReader::new(input), &mut encoder)?;
+    encoder.finish()?;
+    let compressed_size = fs::metadata(&compressed_path)?.len();
+    fs::remove_file(path)?;
+    Ok(compressed_size)
 }

--- a/tools/archiver/src/lib.rs
+++ b/tools/archiver/src/lib.rs
@@ -79,6 +79,10 @@ struct FileEntry {
     last_timestamp: u64,
     event_types: Vec<String>,
     checksum: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    compressed_size_bytes: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    compressed_checksum: Option<String>,
 }
 
 /// Holds session-level state that persists across file rotations.
@@ -101,30 +105,73 @@ impl SessionState {
     }
 }
 
+struct TrackingWriter {
+    inner: BufWriter<File>,
+    hasher: Sha256,
+    bytes_written: u64,
+}
+
+impl Write for TrackingWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let written = self.inner.write(buf)?;
+        self.hasher.update(&buf[..written]);
+        self.bytes_written += written as u64;
+        Ok(written)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.inner.flush()
+    }
+}
+
+struct CompressedStats {
+    checksum: String,
+    size_bytes: u64,
+}
+
 enum ArchiveWriter {
     Plain(BufWriter<File>),
-    Zstd(zstd::Encoder<'static, BufWriter<File>>),
+    Zstd(zstd::Encoder<'static, TrackingWriter>),
 }
 
 impl ArchiveWriter {
     fn new(file: File, compression_level: i32) -> std::io::Result<Self> {
+        if compression_level < 0 {
+            return Err(std::io::Error::other("compression_level must be >= 0"));
+        }
         if compression_level > 0 {
-            Ok(Self::Zstd(zstd::Encoder::new(
-                BufWriter::new(file),
-                compression_level,
-            )?))
+            let tracker = TrackingWriter {
+                inner: BufWriter::new(file),
+                hasher: Sha256::new(),
+                bytes_written: 0,
+            };
+            let encoder = zstd::Encoder::new(tracker, compression_level)?;
+            Ok(Self::Zstd(encoder))
         } else {
             Ok(Self::Plain(BufWriter::new(file)))
         }
     }
 
-    fn finish(self) -> std::io::Result<()> {
+    fn compressed_bytes(&self) -> Option<u64> {
         match self {
-            Self::Plain(mut writer) => writer.flush(),
+            Self::Plain(_) => None,
+            Self::Zstd(encoder) => Some(encoder.get_ref().bytes_written),
+        }
+    }
+
+    fn finish(self) -> std::io::Result<Option<CompressedStats>> {
+        match self {
+            Self::Plain(mut writer) => {
+                writer.flush()?;
+                Ok(None)
+            }
             Self::Zstd(encoder) => {
-                let mut inner = encoder.finish()?;
-                inner.flush()?;
-                Ok(())
+                let mut tracker = encoder.finish()?;
+                tracker.flush()?;
+                Ok(Some(CompressedStats {
+                    size_bytes: tracker.bytes_written,
+                    checksum: format!("{:x}", tracker.hasher.finalize()),
+                }))
             }
         }
     }
@@ -211,11 +258,14 @@ impl ArchiveFile {
     }
 
     fn needs_rotation(&self, max_file_size: u64) -> bool {
-        self.bytes_written >= max_file_size
+        match self.writer.compressed_bytes() {
+            Some(size) => size >= max_file_size,
+            None => self.bytes_written >= max_file_size,
+        }
     }
 
     fn finalize(self, name: String) -> std::io::Result<(PathBuf, FileEntry)> {
-        self.writer.finish()?;
+        let compressed_stats = self.writer.finish()?;
         let checksum = format!("{:x}", self.hasher.finalize());
         let mut sorted_types: Vec<String> =
             self.event_types.into_iter().map(String::from).collect();
@@ -228,6 +278,8 @@ impl ArchiveFile {
             last_timestamp: self.last_timestamp,
             event_types: sorted_types,
             checksum,
+            compressed_size_bytes: compressed_stats.as_ref().map(|s| s.size_bytes),
+            compressed_checksum: compressed_stats.map(|s| s.checksum),
         };
         Ok((self.path, entry))
     }
@@ -248,7 +300,7 @@ pub struct Args {
     #[arg(short, long, default_value = "archive")]
     pub base_name: String,
 
-    /// Maximum uncompressed file size in bytes before rotation (default: 1GB).
+    /// Maximum compressed output size in bytes before rotation (default: 1GB).
     #[arg(long, default_value_t = 1_073_741_824)]
     pub max_file_size: u64,
 

--- a/tools/archiver/src/lib.rs
+++ b/tools/archiver/src/lib.rs
@@ -354,7 +354,7 @@ pub struct Args {
 
 impl Args {
     /// Returns true if all event types should be archived (no filters specified).
-    pub fn show_all(&self) -> bool {
+    pub fn compress_all(&self) -> bool {
         !(self.messages
             || self.connections
             || self.addrman
@@ -367,10 +367,10 @@ impl Args {
 }
 
 pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(), RuntimeError> {
-    if args.show_all() {
-        log::info!("archiving all events: {}", args.show_all());
+    if args.compress_all() {
+        log::info!("archiving all events: {}", args.compress_all());
     } else {
-        log::info!("archiving all events:           {}", args.show_all());
+        log::info!("archiving all events:           {}", args.compress_all());
         log::info!("archiving P2P messages:         {}", args.messages);
         log::info!("archiving P2P connections:      {}", args.connections);
         log::info!("archiving addrman events:       {}", args.addrman);
@@ -477,7 +477,7 @@ fn rotate(
 }
 
 fn should_archive(event: &Event, args: &Args) -> bool {
-    if args.show_all() {
+    if args.compress_all() {
         return true;
     }
     match event_type_name(event) {

--- a/tools/archiver/src/lib.rs
+++ b/tools/archiver/src/lib.rs
@@ -57,25 +57,15 @@ impl ArchiveHeader {
 #[derive(Serialize)]
 #[serde(crate = "shared::serde")]
 struct Manifest<'a> {
-    session: Session,
     files: &'a [FileEntry],
-}
-
-#[derive(Serialize)]
-#[serde(crate = "shared::serde")]
-struct Session {
-    version: u8,
-    nats_address: String,
-    created_at: u64,
-    finished_at: u64,
-    total_events: u64,
-    total_files: u32,
 }
 
 #[derive(Serialize)]
 #[serde(crate = "shared::serde")]
 struct FileEntry {
     name: String,
+    version: u8,
+    nats_address: String,
     size_bytes: u64,
     events: u64,
     first_timestamp: u64,
@@ -88,21 +78,19 @@ struct FileEntry {
     compressed_checksum: Option<String>,
 }
 
-/// Holds session-level state that persists across file rotations.
+/// Holds state that persists across file rotations.
 struct SessionState {
-    created_at: u64,
-    file_index: u32,
+    started_at_ms: u64,
     manifest_files: Vec<FileEntry>,
 }
 
 impl SessionState {
     fn new() -> Self {
         Self {
-            created_at: SystemTime::now()
+            started_at_ms: SystemTime::now()
                 .duration_since(UNIX_EPOCH)
                 .unwrap()
                 .as_millis() as u64,
-            file_index: 0,
             manifest_files: Vec::new(),
         }
     }
@@ -209,19 +197,36 @@ struct ArchiveFile {
 }
 
 impl ArchiveFile {
-    fn new(
-        output_dir: &Path,
-        base_name: &str,
-        index: u32,
-        compression_level: u32,
-    ) -> std::io::Result<Self> {
+    fn new(output_dir: &Path, base_name: &str, compression_level: u32) -> std::io::Result<Self> {
         let ext = if compression_level > 0 {
             "bin.zst"
         } else {
             "bin"
         };
-        let path = output_dir.join(format!("{}.{}.{}", base_name, index, ext));
-        let file = File::create(&path)?;
+        // Retry on rare timestamp collisions (e.g. fast rotations in tests)
+        let (path, file) = loop {
+            let ts = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_millis() as u64;
+            let path = output_dir.join(format!("{}.{}.{}", base_name, ts, ext));
+            match fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&path)
+            {
+                Ok(file) => break (path, file),
+                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                    std::thread::sleep(std::time::Duration::from_millis(1));
+                }
+                Err(e) => {
+                    return Err(std::io::Error::new(
+                        e.kind(),
+                        format!("failed to create archive {}: {}", path.display(), e),
+                    ))
+                }
+            }
+        };
         let mut writer = ArchiveWriter::new(file, compression_level)?;
         let mut hasher = Sha256::new();
         // header: 16 bytes = MAGIC "PA" (2B) + VERSION (1B) + GIT_HASH (4B) + reserved (9B)
@@ -264,7 +269,7 @@ impl ArchiveFile {
         }
     }
 
-    fn finalize(self, name: String) -> std::io::Result<(PathBuf, FileEntry)> {
+    fn finalize(self, name: String, nats_address: &str) -> std::io::Result<(PathBuf, FileEntry)> {
         let compressed_stats = self.writer.finish()?;
         let checksum = format!("{:x}", self.hasher.finalize());
         let mut sorted_types: Vec<String> =
@@ -272,6 +277,8 @@ impl ArchiveFile {
         sorted_types.sort();
         let entry = FileEntry {
             name,
+            version: VERSION,
+            nats_address: nats_address.to_string(),
             size_bytes: self.bytes_written,
             events: self.events,
             first_timestamp: self.first_timestamp,
@@ -296,7 +303,7 @@ pub struct Args {
     #[arg(short, long)]
     pub output_dir: PathBuf,
 
-    /// Base name for archive files (e.g., "mainnet" -> "mainnet.0.bin").
+    /// Base name for archive files (e.g., "mainnet" -> "mainnet.<timestamp>.bin.zst").
     #[arg(short, long, default_value = "archive")]
     pub base_name: String,
 
@@ -383,12 +390,8 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
 
     fs::create_dir_all(&args.output_dir)?;
     let mut session = SessionState::new();
-    let mut current_file = ArchiveFile::new(
-        &args.output_dir,
-        &args.base_name,
-        session.file_index,
-        args.compression_level,
-    )?;
+    let mut current_file =
+        ArchiveFile::new(&args.output_dir, &args.base_name, args.compression_level)?;
     log::info!("Created archive file: {}", current_file.path.display());
 
     loop {
@@ -431,8 +434,8 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
         }
     }
 
-    let total_files = session.file_index + 1;
     close_file(current_file, &mut session, &args)?;
+    let total_files = session.manifest_files.len();
     let total_events: u64 = session.manifest_files.iter().map(|f| f.events).sum();
 
     log::info!(
@@ -450,13 +453,14 @@ fn close_file(
     session: &mut SessionState,
     args: &Args,
 ) -> std::io::Result<()> {
-    let ext = if args.compression_level > 0 {
-        "bin.zst"
-    } else {
-        "bin"
-    };
-    let name = format!("{}.{}.{}", args.base_name, session.file_index, ext);
-    let (_path, entry) = current_file.finalize(name)?;
+    let name = current_file
+        .path
+        .file_name()
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_string();
+    let (_path, entry) = current_file.finalize(name, &args.nats.address)?;
     session.manifest_files.push(entry);
 
     write_manifest(session, args)
@@ -469,13 +473,7 @@ fn rotate(
     args: &Args,
 ) -> std::io::Result<ArchiveFile> {
     close_file(current_file, session, args)?;
-    session.file_index += 1;
-    ArchiveFile::new(
-        &args.output_dir,
-        &args.base_name,
-        session.file_index,
-        args.compression_level,
-    )
+    ArchiveFile::new(&args.output_dir, &args.base_name, args.compression_level)
 }
 
 fn should_archive(event: &Event, args: &Args) -> bool {
@@ -512,24 +510,13 @@ fn event_type_name(event: &Event) -> Option<&'static str> {
 }
 
 fn write_manifest(session: &SessionState, args: &Args) -> std::io::Result<()> {
-    let finished_at = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_millis() as u64;
     let manifest = Manifest {
-        session: Session {
-            version: VERSION,
-            nats_address: args.nats.address.clone(),
-            created_at: session.created_at,
-            finished_at,
-            total_events: session.manifest_files.iter().map(|file| file.events).sum(),
-            total_files: session.manifest_files.len() as u32,
-        },
         files: &session.manifest_files,
     };
-    let manifest_path = args
-        .output_dir
-        .join(format!("{}.manifest.toml", args.base_name));
+    let manifest_path = args.output_dir.join(format!(
+        "{}.{}.manifest.toml",
+        args.base_name, session.started_at_ms
+    ));
     let toml_str = toml::to_string_pretty(&manifest).map_err(std::io::Error::other)?;
     fs::write(&manifest_path, &toml_str)?;
     log::info!("wrote manifest: {}", manifest_path.display());

--- a/tools/archiver/src/lib.rs
+++ b/tools/archiver/src/lib.rs
@@ -21,6 +21,7 @@ use shared::protobuf::ebpf_extractor::ebpf;
 use shared::protobuf::event::event::PeerObserverEvent;
 use shared::protobuf::event::Event;
 use shared::tokio::sync::watch;
+use shared::zstd;
 
 const MAGIC: [u8; 2] = *b"PA";
 const VERSION: u8 = 1;

--- a/tools/archiver/src/lib.rs
+++ b/tools/archiver/src/lib.rs
@@ -14,11 +14,43 @@ use shared::protobuf::event::Event;
 use shared::tokio::sync::watch;
 use std::path::PathBuf;
 
+use std::collections::HashSet;
 use std::fs::{self, File};
 use std::io::{BufWriter, Write};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::Serialize;
+use sha2::{Digest, Sha256};
 
 const MAGIC: &[u8; 8] = b"POBS_ARC";
 const VERSION: u8 = 1;
+
+#[derive(Serialize)]
+struct Manifest<'a> {
+    session: Session,
+    files: &'a [FileEntry],
+}
+
+#[derive(Serialize)]
+struct Session {
+    version: u8,
+    nats_address: String,
+    created_at: u64,
+    finished_at: u64,
+    total_events: u64,
+    total_files: u32,
+}
+
+#[derive(Serialize)]
+struct FileEntry {
+    name: String,
+    size_bytes: u64,
+    events: u64,
+    first_timestamp: u64,
+    last_timestamp: u64,
+    event_types: Vec<String>,
+    checksum: String,
+}
 
 #[derive(Parser, Debug, Clone)]
 #[command(version, about = "Archive peer-observer events to disk")]
@@ -112,14 +144,25 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
     let mut sub = nc.subscribe("*").await?;
     log::info!("Connected to NATS-server at {}", args.nats.address);
 
+    let created_at = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64;
+
     fs::create_dir_all(&args.output_dir)?;
     let mut file_index: u32 = 0;
     let mut bytes_written: u64 = 16; // header
-    let (mut file_path, mut writer) =
+    let (mut file_path, mut writer, mut hasher) =
         create_archive_file(&args.output_dir, &args.base_name, file_index)?;
     log::info!("Created archive file: {}", file_path.display());
 
     let mut event_count: u64 = 0;
+    let mut file_events: u64 = 0;
+    let mut first_timestamp: u64 = 0;
+    let mut last_timestamp: u64 = 0;
+    let mut event_types: HashSet<String> = HashSet::new();
+    let mut manifest_files: Vec<FileEntry> = Vec::new();
+
     loop {
         shared::tokio::select! {
             maybe_msg = sub.next() => {
@@ -127,20 +170,52 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
                 if let Some(msg) = maybe_msg {
                     let event = Event::decode(msg.payload.as_ref())?;
                     if should_archive(&event, &args){
-                        let event_bytes = write_event(&mut writer, &event)?;
+                        let event_bytes = write_event(&mut writer, &event, &mut hasher)?;
                         bytes_written += event_bytes as u64;
                         event_count += 1;
-                        if event_count % 1000 == 0 {
-                            log::info!("archived {} events ({:.2} MB)", event_count, bytes_written as f64 / 1_048_576.0);
+                        file_events += 1;
+
+                        if first_timestamp == 0 {
+                            first_timestamp = event.timestamp;
                         }
+                        last_timestamp = event.timestamp;
+                        event_types.insert(event_type_name(&event));
+
                         if bytes_written >= args.max_file_size {
                             writer.flush()?;
                             log::info!("file rotation: {} reached {:.2} MB", file_path.display(), bytes_written as f64 / 1_048_576.0);
+                            let checksum = format!("{:x}", hasher.finalize());
+                            let mut sorted_types: Vec<String> = event_types.drain().collect();
+                            sorted_types.sort();
+
+                            manifest_files.push(FileEntry {
+                                name: format!("{}.{}.bin", args.base_name, file_index),
+                                size_bytes: bytes_written,
+                                events: file_events,
+                                first_timestamp,
+                                last_timestamp,
+                                event_types: sorted_types,
+                                checksum,
+                            });
+
+                            write_manifest(
+                                &args.output_dir,
+                                &args.base_name,
+                                &args.nats.address,
+                                created_at,
+                                event_count,
+                                &manifest_files,
+                            )?;
+
                             file_index += 1;
                             bytes_written = 16;
-                            let (new_path, new_writer) = create_archive_file(&args.output_dir, &args.base_name, file_index)?;
+                            file_events = 0;
+                            first_timestamp = 0;
+                            last_timestamp = 0;
+                            let (new_path, new_writer, new_hasher) = create_archive_file(&args.output_dir, &args.base_name, file_index)?;
                             file_path = new_path;
                             writer = new_writer;
+                            hasher = new_hasher;
                             log::info!("Created archive file: {}", file_path.display());
                         }
                     }
@@ -165,12 +240,36 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
             }
         }
     }
-    log::info!(
-        "shutting down. total events archived: {}, file: {}",
-        event_count,
-        file_path.display()
-    );
+
     writer.flush()?;
+    let checksum = format!("{:x}", hasher.finalize());
+    let mut sorted_types: Vec<String> = event_types.drain().collect();
+    sorted_types.sort();
+
+    manifest_files.push(FileEntry {
+        name: format!("{}.{}.bin", args.base_name, file_index),
+        size_bytes: bytes_written,
+        events: file_events,
+        first_timestamp,
+        last_timestamp,
+        event_types: sorted_types,
+        checksum,
+    });
+
+    write_manifest(
+        &args.output_dir,
+        &args.base_name,
+        &args.nats.address,
+        created_at,
+        event_count,
+        &manifest_files,
+    )?;
+
+    log::info!(
+        "shutting down. total events archived: {}, files: {}",
+        event_count,
+        file_index + 1
+    );
     Ok(())
 }
 
@@ -192,16 +291,70 @@ fn should_archive(event: &Event, args: &Args) -> bool {
     }
 }
 
-fn write_event(writer: &mut BufWriter<File>, event: &Event) -> std::io::Result<usize> {
+fn event_type_name(event: &Event) -> String {
+    match event.peer_observer_event.as_ref().unwrap() {
+        PeerObserverEvent::EbpfExtractor(e) => match e.ebpf_event.as_ref().unwrap() {
+            ebpf::EbpfEvent::Message(_) => "messages".to_string(),
+            ebpf::EbpfEvent::Connection(_) => "connections".to_string(),
+            ebpf::EbpfEvent::Addrman(_) => "addrman".to_string(),
+            ebpf::EbpfEvent::Mempool(_) => "mempool".to_string(),
+            ebpf::EbpfEvent::Validation(_) => "validation".to_string(),
+        },
+        PeerObserverEvent::RpcExtractor(_) => "rpc".to_string(),
+        PeerObserverEvent::P2pExtractor(_) => "p2p_extractor".to_string(),
+        PeerObserverEvent::LogExtractor(_) => "log_extractor".to_string(),
+    }
+}
+
+fn write_manifest(
+    output_dir: &PathBuf,
+    base_name: &str,
+    nats_address: &str,
+    created_at: u64,
+    event_count: u64,
+    files: &[FileEntry],
+) -> std::io::Result<()> {
+    let finished_at = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64;
+    let manifest = Manifest {
+        session: Session {
+            version: VERSION,
+            nats_address: nats_address.to_string(),
+            created_at,
+            finished_at,
+            total_events: event_count,
+            total_files: files.len() as u32,
+        },
+        files,
+    };
+    let manifest_path = output_dir.join(format!("{}.manifest.toml", base_name));
+    let toml_str = toml::to_string_pretty(&manifest)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+    fs::write(&manifest_path, &toml_str)?;
+    log::info!("wrote manifest: {}", manifest_path.display());
+    Ok(())
+}
+
+fn write_event(
+    writer: &mut BufWriter<File>,
+    event: &Event,
+    hasher: &mut Sha256,
+) -> std::io::Result<usize> {
     let buf = event.encode_length_delimited_to_vec();
     writer.write_all(&buf)?;
+    hasher.update(&buf);
     Ok(buf.len())
 }
 
-fn write_header(writer: &mut BufWriter<File>) -> std::io::Result<()> {
-    writer.write_all(MAGIC)?; // 8 bytes: "POBS_ARC"
-    writer.write_all(&[VERSION])?; // 1 byte
-    writer.write_all(&[0u8; 7])?; // 7 bytes: reserved
+// header: 16 bytes = MAGIC (8B) + VERSION (1B) + reserved (7B)
+fn write_header(writer: &mut BufWriter<File>, hasher: &mut Sha256) -> std::io::Result<()> {
+    let mut header = [0u8; 16];
+    header[..8].copy_from_slice(MAGIC);
+    header[8] = VERSION;
+    writer.write_all(&header)?;
+    hasher.update(&header);
     writer.flush()?;
     Ok(())
 }
@@ -210,10 +363,11 @@ fn create_archive_file(
     output_dir: &PathBuf,
     base_name: &str,
     index: u32,
-) -> std::io::Result<(PathBuf, BufWriter<File>)> {
+) -> std::io::Result<(PathBuf, BufWriter<File>, Sha256)> {
     let file_path = output_dir.join(format!("{}.{}.bin", base_name, index));
     let file = File::create(&file_path)?;
     let mut writer = BufWriter::new(file);
-    write_header(&mut writer)?;
-    Ok((file_path, writer))
+    let mut hasher = Sha256::new();
+    write_header(&mut writer, &mut hasher)?;
+    Ok((file_path, writer, hasher))
 }

--- a/tools/archiver/src/lib.rs
+++ b/tools/archiver/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(feature = "strict", deny(warnings))]
+
 mod error;
 
 pub use error::RuntimeError;
@@ -334,7 +336,7 @@ pub struct Args {
 
 impl Args {
     /// Returns true if all event types should be archived (no filters specified).
-    pub fn compress_all(&self) -> bool {
+    pub fn archive_all(&self) -> bool {
         !(self.messages
             || self.connections
             || self.mempool
@@ -346,10 +348,10 @@ impl Args {
 }
 
 pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(), RuntimeError> {
-    if args.compress_all() {
-        log::info!("archiving all events: {}", args.compress_all());
+    if args.archive_all() {
+        log::info!("archiving all events: {}", args.archive_all());
     } else {
-        log::info!("archiving all events:           {}", args.compress_all());
+        log::info!("archiving all events:           {}", args.archive_all());
         log::info!("archiving P2P messages:         {}", args.messages);
         log::info!("archiving P2P connections:      {}", args.connections);
         log::info!("archiving mempool events:       {}", args.mempool);
@@ -386,13 +388,23 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
                         }
                     };
                     if should_archive(&event, &args){
-                        current_file.write_event(&event)?;
+                        if let Err(e) = current_file.write_event(&event) {
+                            log::error!("failed to write event: {}", e);
+                            break;
+                        }
 
                         if current_file.needs_rotation(args.max_file_size) {
-                            let (total_file_events, new_file) = rotate(current_file, &args)?;
-                            total_events += total_file_events;
-                            total_files += 1;
-                            current_file = new_file
+                            match rotate(current_file, &args) {
+                                Ok((file_events, new_file)) => {
+                                    total_events += file_events;
+                                    total_files += 1;
+                                    current_file = new_file;
+                                }
+                                Err(e) => {
+                                    log::error!("failed to rotate archive: {}", e);
+                                    return Err(e.into());
+                                }
+                            }
                         }
                     }
                 } else {
@@ -457,7 +469,7 @@ fn rotate(current_file: ArchiveFile, args: &Args) -> std::io::Result<(u64, Archi
 }
 
 fn should_archive(event: &Event, args: &Args) -> bool {
-    if args.compress_all() {
+    if args.archive_all() {
         return true;
     }
     match event_type_name(event) {

--- a/tools/archiver/src/lib.rs
+++ b/tools/archiver/src/lib.rs
@@ -113,11 +113,10 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
     log::info!("Connected to NATS-server at {}", args.nats.address);
 
     fs::create_dir_all(&args.output_dir)?;
-    let file_path = args.output_dir.join(format!("{}.0.bin", args.base_name));
-    let file = File::create(&file_path)?;
-    let mut writer = BufWriter::new(file);
-
-    write_header(&mut writer)?;
+    let mut file_index: u32 = 0;
+    let mut bytes_written: u64 = 16; // header
+    let (mut file_path, mut writer) =
+        create_archive_file(&args.output_dir, &args.base_name, file_index)?;
     log::info!("Created archive file: {}", file_path.display());
 
     let mut event_count: u64 = 0;
@@ -128,11 +127,21 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
                 if let Some(msg) = maybe_msg {
                     let event = Event::decode(msg.payload.as_ref())?;
                     if should_archive(&event, &args){
-                        write_event(&mut writer, &event)?;
+                        let event_bytes = write_event(&mut writer, &event)?;
+                        bytes_written += event_bytes as u64;
                         event_count += 1;
                         if event_count % 1000 == 0 {
-                            let size = file_path.metadata().map(|m| m.len()).unwrap_or(0);
-                            log::info!("archived {} events ({:.2} MB)", event_count, size as f64 / 1_048_576.0);
+                            log::info!("archived {} events ({:.2} MB)", event_count, bytes_written as f64 / 1_048_576.0);
+                        }
+                        if bytes_written >= args.max_file_size {
+                            writer.flush()?;
+                            log::info!("file rotation: {} reached {:.2} MB", file_path.display(), bytes_written as f64 / 1_048_576.0);
+                            file_index += 1;
+                            bytes_written = 16;
+                            let (new_path, new_writer) = create_archive_file(&args.output_dir, &args.base_name, file_index)?;
+                            file_path = new_path;
+                            writer = new_writer;
+                            log::info!("Created archive file: {}", file_path.display());
                         }
                     }
                 } else {
@@ -183,10 +192,10 @@ fn should_archive(event: &Event, args: &Args) -> bool {
     }
 }
 
-fn write_event(writer: &mut BufWriter<File>, event: &Event) -> std::io::Result<()> {
+fn write_event(writer: &mut BufWriter<File>, event: &Event) -> std::io::Result<usize> {
     let buf = event.encode_length_delimited_to_vec();
     writer.write_all(&buf)?;
-    Ok(())
+    Ok(buf.len())
 }
 
 fn write_header(writer: &mut BufWriter<File>) -> std::io::Result<()> {
@@ -195,4 +204,16 @@ fn write_header(writer: &mut BufWriter<File>) -> std::io::Result<()> {
     writer.write_all(&[0u8; 7])?; // 7 bytes: reserved
     writer.flush()?;
     Ok(())
+}
+
+fn create_archive_file(
+    output_dir: &PathBuf,
+    base_name: &str,
+    index: u32,
+) -> std::io::Result<(PathBuf, BufWriter<File>)> {
+    let file_path = output_dir.join(format!("{}.{}.bin", base_name, index));
+    let file = File::create(&file_path)?;
+    let mut writer = BufWriter::new(file);
+    write_header(&mut writer)?;
+    Ok((file_path, writer))
 }

--- a/tools/archiver/src/lib.rs
+++ b/tools/archiver/src/lib.rs
@@ -25,8 +25,37 @@ use sha2::{Digest, Sha256};
 
 type CompressionResult = std::io::Result<(u64, usize)>;
 
-const MAGIC: &[u8; 8] = b"POBS_ARC";
+const MAGIC: [u8; 2] = *b"PA";
 const VERSION: u8 = 1;
+const HEADER_SIZE: usize = 16;
+include!(concat!(env!("OUT_DIR"), "/git_hash.rs"));
+
+struct ArchiveHeader {
+    magic: [u8; 2],
+    version: u8,
+    git_hash: [u8; 3],
+    reserved: [u8; 10],
+}
+
+impl ArchiveHeader {
+    fn new(git_hash: [u8; 3]) -> Self {
+        Self {
+            magic: MAGIC,
+            version: VERSION,
+            git_hash,
+            reserved: [0u8; 10],
+        }
+    }
+
+    fn to_bytes(&self) -> [u8; HEADER_SIZE] {
+        let mut buf = [0u8; HEADER_SIZE];
+        buf[0..2].copy_from_slice(&self.magic);
+        buf[2] = self.version;
+        buf[3..6].copy_from_slice(&self.git_hash);
+        buf[6..16].copy_from_slice(&self.reserved);
+        buf
+    }
+}
 
 #[derive(Serialize)]
 struct Manifest<'a> {
@@ -403,13 +432,12 @@ fn write_event(
     Ok(buf.len())
 }
 
-// header: 16 bytes = MAGIC (8B) + VERSION (1B) + reserved (7B)
+// header: 16 bytes = MAGIC "PA" (2B) + VERSION (1B) + GIT_HASH (3B) + reserved (10B)
 fn write_header(writer: &mut BufWriter<File>, hasher: &mut Sha256) -> std::io::Result<()> {
-    let mut header = [0u8; 16];
-    header[..8].copy_from_slice(MAGIC);
-    header[8] = VERSION;
-    writer.write_all(&header)?;
-    hasher.update(&header);
+    let header = ArchiveHeader::new(GIT_HASH);
+    let bytes = header.to_bytes();
+    writer.write_all(&bytes)?;
+    hasher.update(&bytes);
     writer.flush()?;
     Ok(())
 }

--- a/tools/archiver/src/lib.rs
+++ b/tools/archiver/src/lib.rs
@@ -60,12 +60,6 @@ impl ArchiveHeader {
 
 #[derive(Serialize)]
 #[serde(crate = "shared::serde")]
-struct Manifest<'a> {
-    files: &'a [FileEntry],
-}
-
-#[derive(Serialize)]
-#[serde(crate = "shared::serde")]
 struct FileEntry {
     name: String,
     version: u8,
@@ -80,24 +74,6 @@ struct FileEntry {
     compressed_size_bytes: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     compressed_checksum: Option<String>,
-}
-
-/// Holds state that persists across file rotations.
-struct SessionState {
-    started_at_ms: u64,
-    manifest_files: Vec<FileEntry>,
-}
-
-impl SessionState {
-    fn new() -> Self {
-        Self {
-            started_at_ms: SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap()
-                .as_millis() as u64,
-            manifest_files: Vec::new(),
-        }
-    }
 }
 
 struct TrackingWriter {
@@ -191,6 +167,7 @@ impl Write for ArchiveWriter {
 /// check needs_rotation().
 struct ArchiveFile {
     path: PathBuf,
+    formatted_timestamp: String,
     writer: ArchiveWriter,
     hasher: Sha256,
     bytes_written: u64,
@@ -208,20 +185,20 @@ impl ArchiveFile {
             "bin"
         };
         // Retry on rare timestamp collisions (e.g. fast rotations in tests)
-        let (path, file) = loop {
-            let timestamp = format_utc_timestamp(
+        let (path, formatted_timestamp, file) = loop {
+            let formatted_timestamp = format_utc_timestamp(
                 SystemTime::now()
                     .duration_since(UNIX_EPOCH)
                     .unwrap()
                     .as_millis() as u64,
             );
-            let path = output_dir.join(format!("{}.{}.{}", base_name, timestamp, ext));
+            let path = output_dir.join(format!("{}.{}.{}", base_name, formatted_timestamp, ext));
             match fs::OpenOptions::new()
                 .write(true)
                 .create_new(true)
                 .open(&path)
             {
-                Ok(file) => break (path, file),
+                Ok(file) => break (path, formatted_timestamp, file),
                 Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
                     std::thread::sleep(std::time::Duration::from_millis(1));
                 }
@@ -242,6 +219,7 @@ impl ArchiveFile {
         writer.flush()?;
         Ok(Self {
             path,
+            formatted_timestamp,
             writer,
             hasher,
             bytes_written: HEADER_SIZE as u64,
@@ -275,7 +253,7 @@ impl ArchiveFile {
         }
     }
 
-    fn finalize(self, name: String, nats_address: &str) -> std::io::Result<(PathBuf, FileEntry)> {
+    fn finalize(self, name: String, nats_address: &str) -> std::io::Result<FileEntry> {
         let compressed_stats = self.writer.finish()?;
         let checksum = format!("{:x}", self.hasher.finalize());
         let mut sorted_types: Vec<String> =
@@ -294,7 +272,7 @@ impl ArchiveFile {
             compressed_size_bytes: compressed_stats.as_ref().map(|s| s.size_bytes),
             compressed_checksum: compressed_stats.map(|s| s.checksum),
         };
-        Ok((self.path, entry))
+        Ok(entry)
     }
 }
 
@@ -389,10 +367,12 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
     log::info!("Connected to NATS-server at {}", args.nats.address);
 
     fs::create_dir_all(&args.output_dir)?;
-    let mut session = SessionState::new();
     let mut current_file =
         ArchiveFile::new(&args.output_dir, &args.base_name, args.compression_level)?;
     log::info!("Created archive file: {}", current_file.path.display());
+
+    let mut total_events: u64 = 0;
+    let mut total_files: u64 = 0;
 
     loop {
         shared::tokio::select! {
@@ -409,7 +389,10 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
                         current_file.write_event(&event)?;
 
                         if current_file.needs_rotation(args.max_file_size) {
-                            current_file = rotate(current_file, &mut session, &args)?;
+                            let (total_file_events, new_file) = rotate(current_file, &args)?;
+                            total_events += total_file_events;
+                            total_files += 1;
+                            current_file = new_file
                         }
                     }
                 } else {
@@ -434,9 +417,8 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
         }
     }
 
-    close_file(current_file, &mut session, &args)?;
-    let total_files = session.manifest_files.len();
-    let total_events: u64 = session.manifest_files.iter().map(|f| f.events).sum();
+    total_events += close_file(current_file, &args)?;
+    total_files += 1;
 
     log::info!(
         "shutting down. total events archived: {}, files: {}",
@@ -448,11 +430,7 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
 
 /// Finalizes the current archive file, adds its FileEntry to the manifest,
 /// and writes the manifest to disk.
-fn close_file(
-    current_file: ArchiveFile,
-    session: &mut SessionState,
-    args: &Args,
-) -> std::io::Result<()> {
+fn close_file(current_file: ArchiveFile, args: &Args) -> std::io::Result<u64> {
     let name = current_file
         .path
         .file_name()
@@ -460,20 +438,22 @@ fn close_file(
         .to_str()
         .unwrap()
         .to_string();
-    let (_path, entry) = current_file.finalize(name, &args.nats.address)?;
-    session.manifest_files.push(entry);
 
-    write_manifest(session, args)
+    let manifest_path = args.output_dir.join(format!(
+        "{}.{}.manifest.toml",
+        args.base_name, current_file.formatted_timestamp
+    ));
+    let entry = current_file.finalize(name, &args.nats.address)?;
+
+    write_manifest(&entry, &manifest_path)?;
+    Ok(entry.events)
 }
 
 /// Closes the current archive file and opens the next one.
-fn rotate(
-    current_file: ArchiveFile,
-    session: &mut SessionState,
-    args: &Args,
-) -> std::io::Result<ArchiveFile> {
-    close_file(current_file, session, args)?;
-    ArchiveFile::new(&args.output_dir, &args.base_name, args.compression_level)
+fn rotate(current_file: ArchiveFile, args: &Args) -> std::io::Result<(u64, ArchiveFile)> {
+    let total_events = close_file(current_file, args)?;
+    let new_file = ArchiveFile::new(&args.output_dir, &args.base_name, args.compression_level)?;
+    Ok((total_events, new_file))
 }
 
 fn should_archive(event: &Event, args: &Args) -> bool {
@@ -507,18 +487,10 @@ fn event_type_name(event: &Event) -> Option<&'static str> {
     Some(name)
 }
 
-fn write_manifest(session: &SessionState, args: &Args) -> std::io::Result<()> {
-    let manifest = Manifest {
-        files: &session.manifest_files,
-    };
-    let manifest_path = args.output_dir.join(format!(
-        "{}.{}.manifest.toml",
-        args.base_name,
-        format_utc_timestamp(session.started_at_ms)
-    ));
-    let toml_str = toml::to_string_pretty(&manifest).map_err(std::io::Error::other)?;
-    fs::write(&manifest_path, &toml_str)?;
-    log::info!("wrote manifest: {}", manifest_path.display());
+fn write_manifest(entry: &FileEntry, path: &Path) -> std::io::Result<()> {
+    let toml_str = toml::to_string_pretty(entry).map_err(std::io::Error::other)?;
+    fs::write(path, &toml_str)?;
+    log::info!("wrote manifest: {}", path.display());
     Ok(())
 }
 

--- a/tools/archiver/src/lib.rs
+++ b/tools/archiver/src/lib.rs
@@ -1,0 +1,198 @@
+mod error;
+
+pub use error::RuntimeError;
+
+use shared::clap;
+use shared::clap::Parser;
+use shared::futures::stream::StreamExt;
+use shared::log;
+use shared::nats_util;
+use shared::prost::Message;
+use shared::protobuf::ebpf_extractor::ebpf;
+use shared::protobuf::event::event::PeerObserverEvent;
+use shared::protobuf::event::Event;
+use shared::tokio::sync::watch;
+use std::path::PathBuf;
+
+use std::fs::{self, File};
+use std::io::{BufWriter, Write};
+
+const MAGIC: &[u8; 8] = b"POBS_ARC";
+const VERSION: u8 = 1;
+
+#[derive(Parser, Debug, Clone)]
+#[command(version, about = "Archive peer-observer events to disk")]
+pub struct Args {
+    /// Arguments for the connection to the NATS server.
+    #[command(flatten)]
+    pub nats: nats_util::NatsArgs,
+
+    /// Output directory for archive files.
+    #[arg(short, long)]
+    pub output_dir: PathBuf,
+
+    /// Base name for archive files (e.g., "mainnet" -> "mainnet.0.bin").
+    #[arg(short, long, default_value = "archive")]
+    pub base_name: String,
+
+    /// Maximum file size in bytes before rotation (default: 1GB).
+    #[arg(long, default_value_t = 1_073_741_824)]
+    pub max_file_size: u64,
+
+    /// The log level the tool should run on.
+    #[arg(short, long, default_value_t = log::Level::Info)]
+    pub log_level: log::Level,
+
+    /// If passed, archive P2P message events.
+    #[arg(long)]
+    pub messages: bool,
+
+    /// If passed, archive P2P connection events.
+    #[arg(long)]
+    pub connections: bool,
+
+    /// If passed, archive addrman events.
+    #[arg(long)]
+    pub addrman: bool,
+
+    /// If passed, archive mempool events.
+    #[arg(long)]
+    pub mempool: bool,
+
+    /// If passed, archive validation events.
+    #[arg(long)]
+    pub validation: bool,
+
+    /// If passed, archive RPC events.
+    #[arg(long)]
+    pub rpc: bool,
+
+    /// If passed, archive p2p-extractor events.
+    #[arg(long)]
+    pub p2p_extractor: bool,
+
+    /// If passed, archive log-extractor events.
+    #[arg(long)]
+    pub log_extractor: bool,
+}
+
+impl Args {
+    /// Returns true if all event types should be archived (no filters specified).
+    pub fn show_all(&self) -> bool {
+        !(self.messages
+            || self.connections
+            || self.addrman
+            || self.mempool
+            || self.validation
+            || self.rpc
+            || self.p2p_extractor
+            || self.log_extractor)
+    }
+}
+
+pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(), RuntimeError> {
+    if args.show_all() {
+        log::info!("archiving all events: {}", args.show_all());
+    } else {
+        log::info!("archiving all events:           {}", args.show_all());
+        log::info!("archiving P2P messages:         {}", args.messages);
+        log::info!("archiving P2P connections:      {}", args.connections);
+        log::info!("archiving addrman events:       {}", args.addrman);
+        log::info!("archiving mempool events:       {}", args.mempool);
+        log::info!("archiving validation events:    {}", args.validation);
+        log::info!("archiving rpc events:           {}", args.rpc);
+        log::info!("archiving p2p_extractor events: {}", args.p2p_extractor);
+        log::info!("archiving log_extractor events: {}", args.log_extractor);
+    }
+
+    let nc = nats_util::prepare_connection(&args.nats)?
+        .connect(&args.nats.address)
+        .await?;
+
+    let mut sub = nc.subscribe("*").await?;
+    log::info!("Connected to NATS-server at {}", args.nats.address);
+
+    fs::create_dir_all(&args.output_dir)?;
+    let file_path = args.output_dir.join(format!("{}.0.bin", args.base_name));
+    let file = File::create(&file_path)?;
+    let mut writer = BufWriter::new(file);
+
+    write_header(&mut writer)?;
+    log::info!("Created archive file: {}", file_path.display());
+
+    let mut event_count: u64 = 0;
+    loop {
+        shared::tokio::select! {
+            maybe_msg = sub.next() => {
+
+                if let Some(msg) = maybe_msg {
+                    let event = Event::decode(msg.payload.as_ref())?;
+                    if should_archive(&event, &args){
+                        write_event(&mut writer, &event)?;
+                        event_count += 1;
+                        if event_count % 1000 == 0 {
+                            let size = file_path.metadata().map(|m| m.len()).unwrap_or(0);
+                            log::info!("archived {} events ({:.2} MB)", event_count, size as f64 / 1_048_576.0);
+                        }
+                    }
+                } else {
+                    break; // subscription ended
+                }
+            }
+            res = shutdown_rx.changed() => {
+                match res {
+                    Ok(_) => {
+                        if *shutdown_rx.borrow() {
+                            log::info!("archiver tool received shutdown signal.");
+                            break;
+                        }
+                    }
+                    Err(_) => {
+                        // all senders dropped -> treat as shutdown
+                        log::warn!("The shutdown notification sender was dropped. Shutting down.");
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    log::info!(
+        "shutting down. total events archived: {}, file: {}",
+        event_count,
+        file_path.display()
+    );
+    writer.flush()?;
+    Ok(())
+}
+
+fn should_archive(event: &Event, args: &Args) -> bool {
+    if args.show_all() {
+        return true;
+    }
+    match event.peer_observer_event.as_ref().unwrap() {
+        PeerObserverEvent::EbpfExtractor(ebpf) => match ebpf.ebpf_event.as_ref().unwrap() {
+            ebpf::EbpfEvent::Message(_) => args.messages,
+            ebpf::EbpfEvent::Connection(_) => args.connections,
+            ebpf::EbpfEvent::Addrman(_) => args.addrman,
+            ebpf::EbpfEvent::Mempool(_) => args.mempool,
+            ebpf::EbpfEvent::Validation(_) => args.validation,
+        },
+        PeerObserverEvent::RpcExtractor(_) => args.rpc,
+        PeerObserverEvent::P2pExtractor(_) => args.p2p_extractor,
+        PeerObserverEvent::LogExtractor(_) => args.log_extractor,
+    }
+}
+
+fn write_event(writer: &mut BufWriter<File>, event: &Event) -> std::io::Result<()> {
+    let buf = event.encode_length_delimited_to_vec();
+    writer.write_all(&buf)?;
+    Ok(())
+}
+
+fn write_header(writer: &mut BufWriter<File>) -> std::io::Result<()> {
+    writer.write_all(MAGIC)?; // 8 bytes: "POBS_ARC"
+    writer.write_all(&[VERSION])?; // 1 byte
+    writer.write_all(&[0u8; 7])?; // 7 bytes: reserved
+    writer.flush()?;
+    Ok(())
+}

--- a/tools/archiver/src/main.rs
+++ b/tools/archiver/src/main.rs
@@ -1,0 +1,29 @@
+use archiver::Args;
+use shared::log;
+use shared::tokio::{self, signal, sync::watch};
+use shared::{clap::Parser, simple_logger};
+
+#[tokio::main]
+async fn main() {
+    let args = Args::parse();
+
+    if let Err(e) = simple_logger::init_with_level(args.log_level) {
+        eprintln!("archiver tool error: {}", e);
+    }
+
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let archiver_handle = tokio::spawn(archiver::run(args, shutdown_rx));
+
+    tokio::select! {
+        _ = signal::ctrl_c() => {
+            log::info!("Received Ctrl+C. Stopping...");
+            let _ = shutdown_tx.send(true);
+        }
+        result = archiver_handle => {
+            match result.unwrap() {
+                Ok(_) => log::info!("archiver task completed."),
+                Err(e) => log::error!("archiver task failed: {e}"),
+            }
+        }
+    }
+}

--- a/tools/archiver/src/main.rs
+++ b/tools/archiver/src/main.rs
@@ -12,18 +12,24 @@ async fn main() {
     }
 
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
-    let archiver_handle = tokio::spawn(archiver::run(args, shutdown_rx));
+    let mut archiver_handle = tokio::spawn(archiver::run(args, shutdown_rx));
 
     tokio::select! {
         _ = signal::ctrl_c() => {
             log::info!("Received Ctrl+C. Stopping...");
             let _ = shutdown_tx.send(true);
         }
-        result = archiver_handle => {
+        result = &mut archiver_handle => {
             match result.unwrap() {
                 Ok(_) => log::info!("archiver task completed."),
                 Err(e) => log::error!("archiver task failed: {e}"),
             }
+            return;
         }
+    }
+
+    match archiver_handle.await.unwrap() {
+        Ok(_) => log::info!("archiver task completed."),
+        Err(e) => log::error!("archiver task failed: {e}"),
     }
 }

--- a/tools/archiver/tests/integration.rs
+++ b/tools/archiver/tests/integration.rs
@@ -30,6 +30,15 @@ use std::{fs::File, io::Read, sync::Once, time::Duration};
 
 static INIT: Once = Once::new();
 
+fn find_files(dir: &std::path::Path, suffix: &str) -> Vec<std::path::PathBuf> {
+    std::fs::read_dir(dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_name().to_string_lossy().ends_with(suffix))
+        .map(|e| e.path())
+        .collect()
+}
+
 fn setup() {
     INIT.call_once(|| {
         simple_logger::SimpleLogger::new()
@@ -233,7 +242,11 @@ async fn run_filter_test(flag: &str, expected_count: usize) {
     shutdown_tx.send(true).unwrap();
     archiver_handle.await.unwrap();
 
-    let file = File::open(tmp_dir.join("test.0.bin.zst")).unwrap();
+    let archive_path = find_files(&tmp_dir, ".bin.zst")
+        .into_iter()
+        .next()
+        .expect("expected a .0.bin.zst file");
+    let file = File::open(archive_path).unwrap();
     let mut reader = zstd::Decoder::new(file).unwrap();
 
     let mut header = [0u8; 16];
@@ -412,7 +425,11 @@ async fn test_replayer_roundtrip() {
     shutdown_tx.send(true).unwrap();
     archiver_handle.await.unwrap();
 
-    let archive = replayer::read_archive(&tmp_dir.join("test.0.bin.zst")).unwrap();
+    let archive_path = find_files(&tmp_dir, ".bin.zst")
+        .into_iter()
+        .next()
+        .expect("expected a .0.bin.zst file");
+    let archive = replayer::read_archive(&archive_path).unwrap();
 
     assert_eq!(archive.header.version, 1);
     assert_eq!(archive.events.len(), all_events.len());
@@ -458,9 +475,10 @@ async fn test_replayer_roundtrip_uncompressed() {
     shutdown_tx.send(true).unwrap();
     archiver_handle.await.unwrap();
 
-    let archive_path = tmp_dir.join("test.0.bin");
-    assert!(archive_path.exists());
-
+    let archive_path = find_files(&tmp_dir, ".bin")
+        .into_iter()
+        .next()
+        .expect("expected a .0.bin file");
     let archive = replayer::read_archive(&archive_path).unwrap();
 
     assert_eq!(archive.header.version, 1);
@@ -505,7 +523,11 @@ async fn test_compression_integrity() {
     shutdown_tx.send(true).unwrap();
     archiver_handle.await.unwrap();
 
-    let manifest_str = std::fs::read_to_string(tmp_dir.join("test.manifest.toml")).unwrap();
+    let manifest_path = find_files(&tmp_dir, ".manifest.toml")
+        .into_iter()
+        .next()
+        .expect("expected a manifest file");
+    let manifest_str = std::fs::read_to_string(manifest_path).unwrap();
     let manifest: toml::Value = manifest_str.parse().unwrap();
     let files = manifest["files"].as_array().unwrap();
 
@@ -588,19 +610,23 @@ async fn test_no_compression() {
     archiver_handle.await.unwrap();
 
     // should be .bin, not .bin.zst
-    let bin_path = tmp_dir.join("test.0.bin");
-    let zst_path = tmp_dir.join("test.0.bin.zst");
-    assert!(bin_path.exists(), "test.0.bin should exist");
-    assert!(!zst_path.exists(), "test.0.bin.zst should not exist");
+    let bin_files = find_files(&tmp_dir, ".bin");
+    assert!(!bin_files.is_empty(), ".0.bin file should exist");
+    let zst_files = find_files(&tmp_dir, ".bin.zst");
+    assert!(zst_files.is_empty(), ".0.bin.zst file should not exist");
 
     // manifest should reference .bin
-    let manifest_str = std::fs::read_to_string(tmp_dir.join("test.manifest.toml")).unwrap();
+    let manifest_path = find_files(&tmp_dir, ".manifest.toml")
+        .into_iter()
+        .next()
+        .expect("expected a manifest file");
+    let manifest_str = std::fs::read_to_string(manifest_path).unwrap();
     let manifest: toml::Value = manifest_str.parse().unwrap();
     let files = manifest["files"].as_array().unwrap();
-    assert_eq!(files[0]["name"].as_str().unwrap(), "test.0.bin");
+    assert!(files[0]["name"].as_str().unwrap().ends_with(".bin"));
 
     // checksum should match raw file content
-    let raw = std::fs::read(&bin_path).unwrap();
+    let raw = std::fs::read(&bin_files[0]).unwrap();
     let actual_checksum = format!("{:x}", sha2::Sha256::digest(&raw));
     let expected_checksum = files[0]["checksum"].as_str().unwrap();
     assert_eq!(

--- a/tools/archiver/tests/integration.rs
+++ b/tools/archiver/tests/integration.rs
@@ -336,6 +336,26 @@ async fn test_file_rotation_with_compression() {
         zst_files.len()
     );
 
+    let manifest_files = find_files(&tmp_dir, ".manifest.toml");
+    let mut archive_names: Vec<_> = zst_files
+        .iter()
+        .map(|e| e.file_name().to_string_lossy().to_string())
+        .collect();
+    let mut manifest_names: Vec<_> = manifest_files
+        .iter()
+        .map(|p| {
+            let manifest_str = std::fs::read_to_string(p).unwrap();
+            let manifest: toml::Value = manifest_str.parse().unwrap();
+            manifest["name"].as_str().unwrap().to_string()
+        })
+        .collect();
+    archive_names.sort();
+    manifest_names.sort();
+    assert_eq!(
+        archive_names, manifest_names,
+        "each manifest must reference exactly one unique archive file"
+    );
+
     // decompress and count total events
     let mut total_events = 0;
     for entry in &zst_files {
@@ -504,51 +524,47 @@ async fn test_compression_integrity() {
         .expect("expected a manifest file");
     let manifest_str = std::fs::read_to_string(manifest_path).unwrap();
     let manifest: toml::Value = manifest_str.parse().unwrap();
-    let files = manifest["files"].as_array().unwrap();
+    let zst_name = manifest["name"].as_str().unwrap();
+    let expected_checksum = manifest["checksum"].as_str().unwrap();
 
-    for entry in files {
-        let zst_name = entry["name"].as_str().unwrap();
-        let expected_checksum = entry["checksum"].as_str().unwrap();
+    let zst_path = tmp_dir.join(zst_name);
+    let bin_path = tmp_dir.join(zst_name.strip_suffix(".zst").unwrap());
 
-        let zst_path = tmp_dir.join(zst_name);
-        let bin_path = tmp_dir.join(zst_name.strip_suffix(".zst").unwrap());
+    assert!(zst_path.exists(), "{} should exist", zst_name);
+    assert!(
+        !bin_path.exists(),
+        "{} should have been deleted",
+        bin_path.display()
+    );
 
-        assert!(zst_path.exists(), "{} should exist", zst_name);
-        assert!(
-            !bin_path.exists(),
-            "{} should have been deleted",
-            bin_path.display()
-        );
+    let file = File::open(&zst_path).unwrap();
+    let mut decoder = zstd::Decoder::new(file).unwrap();
+    let mut decompressed = Vec::new();
+    decoder.read_to_end(&mut decompressed).unwrap();
 
-        let file = File::open(&zst_path).unwrap();
-        let mut decoder = zstd::Decoder::new(file).unwrap();
-        let mut decompressed = Vec::new();
-        decoder.read_to_end(&mut decompressed).unwrap();
+    let actual_checksum = format!("{:x}", sha2::Sha256::digest(&decompressed));
 
-        let actual_checksum = format!("{:x}", sha2::Sha256::digest(&decompressed));
+    assert_eq!(
+        actual_checksum, expected_checksum,
+        "decompressed SHA-256 of {} must match manifest checksum",
+        zst_name
+    );
 
-        assert_eq!(
-            actual_checksum, expected_checksum,
-            "decompressed SHA-256 of {} must match manifest checksum",
-            zst_name
-        );
+    let compressed_checksum = manifest["compressed_checksum"].as_str().unwrap();
+    let compressed_size = manifest["compressed_size_bytes"].as_integer().unwrap() as u64;
 
-        let compressed_checksum = entry["compressed_checksum"].as_str().unwrap();
-        let compressed_size = entry["compressed_size_bytes"].as_integer().unwrap() as u64;
+    let raw_zst = std::fs::read(&zst_path).unwrap();
+    let actual_compressed_checksum = format!("{:x}", sha2::Sha256::digest(&raw_zst));
+    assert_eq!(
+        actual_compressed_checksum, compressed_checksum,
+        "SHA-256 of raw .zst must match manifest compressed_checksum"
+    );
 
-        let raw_zst = std::fs::read(&zst_path).unwrap();
-        let actual_compressed_checksum = format!("{:x}", sha2::Sha256::digest(&raw_zst));
-        assert_eq!(
-            actual_compressed_checksum, compressed_checksum,
-            "SHA-256 of raw .zst must match manifest compressed_checksum"
-        );
-
-        let file_size = std::fs::metadata(&zst_path).unwrap().len();
-        assert_eq!(
-            compressed_size, file_size,
-            "compressed_size_bytes must match file size on disk"
-        );
-    }
+    let file_size = std::fs::metadata(&zst_path).unwrap().len();
+    assert_eq!(
+        compressed_size, file_size,
+        "compressed_size_bytes must match file size on disk"
+    );
 
     let _ = std::fs::remove_dir_all(&tmp_dir);
 }
@@ -597,24 +613,23 @@ async fn test_no_compression() {
         .expect("expected a manifest file");
     let manifest_str = std::fs::read_to_string(manifest_path).unwrap();
     let manifest: toml::Value = manifest_str.parse().unwrap();
-    let files = manifest["files"].as_array().unwrap();
-    assert!(files[0]["name"].as_str().unwrap().ends_with(".bin"));
+    assert!(manifest["name"].as_str().unwrap().ends_with(".bin"));
 
     // checksum should match raw file content
     let raw = std::fs::read(&bin_files[0]).unwrap();
     let actual_checksum = format!("{:x}", sha2::Sha256::digest(&raw));
-    let expected_checksum = files[0]["checksum"].as_str().unwrap();
+    let expected_checksum = manifest["checksum"].as_str().unwrap();
     assert_eq!(
         actual_checksum, expected_checksum,
         "SHA-256 of raw .bin must match manifest checksum"
     );
 
     assert!(
-        files[0].get("compressed_checksum").is_none(),
+        manifest.get("compressed_checksum").is_none(),
         "compressed_checksum should not be present without compression"
     );
     assert!(
-        files[0].get("compressed_size_bytes").is_none(),
+        manifest.get("compressed_size_bytes").is_none(),
         "compressed_size_bytes should not be present without compression"
     );
 

--- a/tools/archiver/tests/integration.rs
+++ b/tools/archiver/tests/integration.rs
@@ -245,7 +245,7 @@ async fn run_filter_test(flag: &str, expected_count: usize) {
     let archive_path = find_files(&tmp_dir, ".bin.zst")
         .into_iter()
         .next()
-        .expect("expected a .0.bin.zst file");
+        .expect("expected a .<timestamp>.bin.zst file");
     let file = File::open(archive_path).unwrap();
     let mut reader = zstd::Decoder::new(file).unwrap();
 
@@ -428,7 +428,7 @@ async fn test_replayer_roundtrip() {
     let archive_path = find_files(&tmp_dir, ".bin.zst")
         .into_iter()
         .next()
-        .expect("expected a .0.bin.zst file");
+        .expect("expected a .<timestamp>.bin.zst file");
     let archive = replayer::read_archive(&archive_path).unwrap();
 
     assert_eq!(archive.header.version, 1);

--- a/tools/archiver/tests/integration.rs
+++ b/tools/archiver/tests/integration.rs
@@ -1,0 +1,459 @@
+#![cfg(feature = "nats_integration_tests")]
+
+use archiver::Args;
+
+use sha2::Digest;
+use shared::{
+    log,
+    nats_subjects::Subject,
+    nats_util,
+    prost::Message,
+    protobuf::{
+        ebpf_extractor::{
+            addrman::{self, InsertNew},
+            connection::{self, Connection, InboundConnection},
+            ebpf,
+            mempool::{self, Added},
+            message::{self, message_event::Msg, Metadata, Ping},
+            validation::{self, BlockConnected},
+            Ebpf,
+        },
+        event::{event::PeerObserverEvent, Event},
+        log_extractor::{self, LogDebugCategory},
+        p2p_extractor, rpc_extractor,
+    },
+    simple_logger,
+    testing::{nats_publisher::NatsPublisherForTesting, nats_server::NatsServerForTesting},
+    tokio::{self, sync::watch, time::sleep},
+};
+use std::{
+    fs::File,
+    io::{BufReader, Read},
+    sync::Once,
+    time::Duration,
+};
+
+static INIT: Once = Once::new();
+
+fn setup() {
+    INIT.call_once(|| {
+        simple_logger::SimpleLogger::new()
+            .with_level(log::LevelFilter::Info)
+            .init()
+            .unwrap();
+    });
+}
+
+fn make_test_args(nats_port: u16, output_dir: &std::path::Path) -> Args {
+    Args {
+        // aqui nao deveria ser Args::new?
+        nats: nats_util::NatsArgs {
+            address: format!("127.0.0.1:{}", nats_port),
+            username: None,
+            password: None,
+            password_file: None,
+        },
+        output_dir: output_dir.to_path_buf(),
+        base_name: "test".to_string(),
+        max_file_size: 1_073_741_824, // nao seria melhor pegar o valor direto de um arquivo configuravel?
+        log_level: log::Level::Info,
+        messages: false,
+        connections: false,
+        addrman: false,
+        mempool: false,
+        validation: false,
+        rpc: false,
+        p2p_extractor: false,
+        log_extractor: false,
+    }
+}
+
+fn make_all_event_types() -> Vec<(Event, &'static str)> {
+    vec![
+        // 1. ebpf message
+        (
+            Event::new(PeerObserverEvent::EbpfExtractor(Ebpf {
+                ebpf_event: Some(ebpf::EbpfEvent::Message(message::MessageEvent {
+                    meta: Metadata {
+                        peer_id: 0,
+                        addr: "127.0.0.1:8333".to_string(),
+                        conn_type: 1,
+                        command: "ping".to_string(),
+                        inbound: true,
+                        size: 8,
+                    },
+                    msg: Some(Msg::Ping(Ping { value: 1337 })),
+                })),
+            }))
+            .unwrap(),
+            "messages",
+        ),
+        // 2. ebpf connection
+        (
+            Event::new(PeerObserverEvent::EbpfExtractor(Ebpf {
+                ebpf_event: Some(ebpf::EbpfEvent::Connection(connection::ConnectionEvent {
+                    event: Some(connection::connection_event::Event::Inbound(
+                        InboundConnection {
+                            conn: Connection {
+                                addr: "127.0.0.1:8333".to_string(),
+                                conn_type: 1,
+                                network: 1,
+                                peer_id: 1,
+                            },
+                            existing_connections: 10,
+                        },
+                    )),
+                })),
+            }))
+            .unwrap(),
+            "connections",
+        ),
+        // 3. ebpf addrman
+        (
+            Event::new(PeerObserverEvent::EbpfExtractor(Ebpf {
+                ebpf_event: Some(ebpf::EbpfEvent::Addrman(addrman::AddrmanEvent {
+                    event: Some(addrman::addrman_event::Event::New(InsertNew {
+                        addr: "127.0.0.1:8333".to_string(),
+                        addr_as: 1,
+                        bucket: 1,
+                        bucket_pos: 1,
+                        inserted: true,
+                        source: "127.0.0.1:8333".to_string(),
+                        source_as: 0,
+                    })),
+                })),
+            }))
+            .unwrap(),
+            "addrman",
+        ),
+        // 4. ebpf mempool
+        (
+            Event::new(PeerObserverEvent::EbpfExtractor(Ebpf {
+                ebpf_event: Some(ebpf::EbpfEvent::Mempool(mempool::MempoolEvent {
+                    event: Some(mempool::mempool_event::Event::Added(Added {
+                        txid: vec![0u8; 32],
+                        vsize: 250,
+                        fee: 1000,
+                    })),
+                })),
+            }))
+            .unwrap(),
+            "mempool",
+        ),
+        // 5. ebpf validation
+        (
+            Event::new(PeerObserverEvent::EbpfExtractor(Ebpf {
+                ebpf_event: Some(ebpf::EbpfEvent::Validation(validation::ValidationEvent {
+                    event: Some(validation::validation_event::Event::BlockConnected(
+                        BlockConnected {
+                            hash: vec![0u8; 32],
+                            height: 800000,
+                            transactions: 3000,
+                            inputs: 5000,
+                            sigops: 10000,
+                            connection_time: 500000,
+                        },
+                    )),
+                })),
+            }))
+            .unwrap(),
+            "validation",
+        ),
+        // 6. rpc
+        (
+            Event::new(PeerObserverEvent::RpcExtractor(rpc_extractor::Rpc {
+                rpc_event: Some(rpc_extractor::rpc::RpcEvent::Uptime(12345)),
+            }))
+            .unwrap(),
+            "rpc",
+        ),
+        // 7. p2p_extractor
+        (
+            Event::new(PeerObserverEvent::P2pExtractor(p2p_extractor::P2p {
+                p2p_event: Some(p2p_extractor::p2p::P2pEvent::PingDuration(
+                    p2p_extractor::PingDuration { duration: 500000 },
+                )),
+            }))
+            .unwrap(),
+            "p2p_extractor",
+        ),
+        // 8. log_extractor
+        (
+            Event::new(PeerObserverEvent::LogExtractor(log_extractor::Log {
+                category: LogDebugCategory::Unknown.into(),
+                log_timestamp: 1234,
+                threadname: String::new(),
+                log_level: log_extractor::LogLevel::Info.into(),
+                log_line_bytes: 8,
+                log_event: Some(log_extractor::log::LogEvent::UnknownLogMessage(
+                    log_extractor::UnknownLogMessage {
+                        raw_message: "test log".to_string(),
+                    },
+                )),
+            }))
+            .unwrap(),
+            "log_extractor",
+        ),
+    ]
+}
+
+async fn run_filter_test(flag: &str, expected_count: usize) {
+    setup();
+
+    let tmp_dir = std::env::temp_dir().join(format!("archiver_test_{}", flag));
+    let _ = std::fs::remove_dir_all(&tmp_dir);
+
+    let nats_server = NatsServerForTesting::new(&[]).await;
+    let nats_publisher = NatsPublisherForTesting::new(nats_server.port).await;
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+
+    let dir = tmp_dir.clone();
+    let flag_owned = flag.to_string();
+    let archiver_handle = tokio::spawn(async move {
+        let mut args = make_test_args(nats_server.port, &dir);
+        match flag_owned.as_str() {
+            "messages" => args.messages = true,
+            "connections" => args.connections = true,
+            "addrman" => args.addrman = true,
+            "mempool" => args.mempool = true,
+            "validation" => args.validation = true,
+            "rpc" => args.rpc = true,
+            "p2p_extractor" => args.p2p_extractor = true,
+            "log_extractor" => args.log_extractor = true,
+            _ => {} // show_all
+        }
+        archiver::run(args, shutdown_rx).await.unwrap();
+    });
+
+    sleep(Duration::from_secs(1)).await;
+
+    let all_events = make_all_event_types();
+    for (event, _label) in &all_events {
+        nats_publisher
+            .publish(Subject::NetMsg.to_string(), event.encode_to_vec())
+            .await;
+    }
+
+    sleep(Duration::from_millis(500)).await;
+    shutdown_tx.send(true).unwrap();
+    archiver_handle.await.unwrap();
+
+    // ler e verificar
+    let file = File::open(tmp_dir.join("test.0.bin")).unwrap();
+    let mut reader = BufReader::new(file);
+
+    let mut header = [0u8; 16];
+    reader.read_exact(&mut header).unwrap();
+    assert_eq!(&header[0..8], b"POBS_ARC");
+
+    let mut buf = Vec::new();
+    reader.read_to_end(&mut buf).unwrap();
+
+    let mut decoded_events = Vec::new();
+    let mut cursor = 0;
+    while cursor < buf.len() {
+        let event = Event::decode_length_delimited(&buf[cursor..]).unwrap();
+        let size = event.encoded_len();
+        let varint_len = shared::prost::length_delimiter_len(size);
+        cursor += varint_len + size;
+        decoded_events.push(event);
+    }
+
+    assert_eq!(decoded_events.len(), expected_count);
+
+    let _ = std::fs::remove_dir_all(&tmp_dir);
+}
+
+#[tokio::test]
+async fn test_filter_all() {
+    run_filter_test("all", 8).await;
+}
+
+#[tokio::test]
+async fn test_filter_messages() {
+    run_filter_test("messages", 1).await;
+}
+
+#[tokio::test]
+async fn test_filter_connections() {
+    run_filter_test("connections", 1).await;
+}
+
+#[tokio::test]
+async fn test_filter_addrman() {
+    run_filter_test("addrman", 1).await;
+}
+
+#[tokio::test]
+async fn test_filter_mempool() {
+    run_filter_test("mempool", 1).await;
+}
+
+#[tokio::test]
+async fn test_filter_validation() {
+    run_filter_test("validation", 1).await;
+}
+
+#[tokio::test]
+async fn test_filter_rpc() {
+    run_filter_test("rpc", 1).await;
+}
+
+#[tokio::test]
+async fn test_filter_p2p_extractor() {
+    run_filter_test("p2p_extractor", 1).await;
+}
+
+#[tokio::test]
+async fn test_filter_log_extractor() {
+    run_filter_test("log_extractor", 1).await;
+}
+
+#[tokio::test]
+async fn test_file_rotation() {
+    setup();
+
+    let tmp_dir = std::env::temp_dir().join("archiver_test_rotation");
+    let _ = std::fs::remove_dir_all(&tmp_dir);
+
+    let nats_server = NatsServerForTesting::new(&[]).await;
+    let nats_publisher = NatsPublisherForTesting::new(nats_server.port).await;
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+
+    let dir = tmp_dir.clone();
+    let archiver_handle = tokio::spawn(async move {
+        let mut args = make_test_args(nats_server.port, &dir);
+        args.max_file_size = 100; // force rotation after ~1-2 events
+        archiver::run(args, shutdown_rx).await.unwrap();
+    });
+
+    sleep(Duration::from_secs(1)).await;
+
+    let all_events = make_all_event_types();
+    for (event, _label) in &all_events {
+        nats_publisher
+            .publish(Subject::NetMsg.to_string(), event.encode_to_vec())
+            .await;
+    }
+
+    sleep(Duration::from_millis(500)).await;
+    shutdown_tx.send(true).unwrap();
+    archiver_handle.await.unwrap();
+
+    // count how many .bin files were created
+    let bin_files: Vec<_> = std::fs::read_dir(&tmp_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            e.path()
+                .extension()
+                .map(|ext| ext == "bin")
+                .unwrap_or(false)
+        })
+        .collect();
+
+    assert!(
+        bin_files.len() > 1,
+        "expected multiple files from rotation, got {}",
+        bin_files.len()
+    );
+
+    // read all files and count total events
+    let mut total_events = 0;
+    for entry in &bin_files {
+        let file = File::open(entry.path()).unwrap();
+        let mut reader = BufReader::new(file);
+
+        let mut header = [0u8; 16];
+        reader.read_exact(&mut header).unwrap();
+        assert_eq!(&header[0..8], b"POBS_ARC");
+
+        let mut buf = Vec::new();
+        reader.read_to_end(&mut buf).unwrap();
+
+        let mut cursor = 0;
+        while cursor < buf.len() {
+            let event = Event::decode_length_delimited(&buf[cursor..]).unwrap();
+            let size = event.encoded_len();
+            let varint_len = shared::prost::length_delimiter_len(size);
+            cursor += varint_len + size;
+            total_events += 1;
+        }
+    }
+
+    println!("\n========== ROTATION TEST ==========");
+    println!("files created: {}", bin_files.len());
+    println!("total events:  {}", total_events);
+    println!("===================================\n");
+
+    assert_eq!(total_events, 8);
+
+    let _ = std::fs::remove_dir_all(&tmp_dir);
+}
+
+#[tokio::test]
+async fn test_compression_integrity() {
+    setup();
+
+    let tmp_dir = std::env::temp_dir().join("archiver_test_compression");
+    let _ = std::fs::remove_dir_all(&tmp_dir);
+
+    let nats_server = NatsServerForTesting::new(&[]).await;
+    let nats_publisher = NatsPublisherForTesting::new(nats_server.port).await;
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+
+    let dir = tmp_dir.clone();
+    let archiver_handle = tokio::spawn(async move {
+        let mut args = make_test_args(nats_server.port, &dir);
+        args.max_file_size = 100;
+        args.compression_level = 3;
+        archiver::run(args, shutdown_rx).await.unwrap();
+    });
+
+    sleep(Duration::from_secs(1)).await;
+
+    let all_events = make_all_event_types();
+    for (event, _) in &all_events {
+        nats_publisher
+            .publish(Subject::NetMsg.to_string(), event.encode_to_vec())
+            .await;
+    }
+
+    sleep(Duration::from_millis(500)).await;
+    shutdown_tx.send(true).unwrap();
+    archiver_handle.await.unwrap();
+
+    let manifest_str = std::fs::read_to_string(tmp_dir.join("test.manifest.toml")).unwrap();
+    let manifest: toml::Value = manifest_str.parse().unwrap();
+    let files = manifest["files"].as_array().unwrap();
+
+    for entry in files {
+        let zst_name = entry["name"].as_str().unwrap();
+        let expected_checksum = entry["checksum"].as_str().unwrap();
+
+        let zst_path = tmp_dir.join(zst_name);
+        let bin_path = tmp_dir.join(zst_name.strip_suffix(".zst").unwrap());
+
+        assert!(zst_path.exists(), "{} should exist", zst_name);
+        assert!(
+            !bin_path.exists(),
+            "{} should have been deleted",
+            bin_path.display()
+        );
+
+        let file = File::open(&zst_path).unwrap();
+        let mut decoder = zstd::Decoder::new(file).unwrap();
+        let mut decompressed = Vec::new();
+        decoder.read_to_end(&mut decompressed).unwrap();
+
+        let actual_checksum = format!("{:x}", sha2::Sha256::digest(&decompressed));
+
+        assert_eq!(
+            actual_checksum, expected_checksum,
+            "decompressed SHA-256 of {} must match manifest checksum",
+            zst_name
+        );
+    }
+
+    let _ = std::fs::remove_dir_all(&tmp_dir);
+}

--- a/tools/archiver/tests/integration.rs
+++ b/tools/archiver/tests/integration.rs
@@ -380,6 +380,49 @@ async fn test_file_rotation() {
     let _ = std::fs::remove_dir_all(&tmp_dir);
 }
 
+/// Archiver writes events, replayer reads them back, verify they match.
+#[tokio::test]
+async fn test_replayer_roundtrip() {
+    setup();
+
+    let tmp_dir = std::env::temp_dir().join("archiver_test_replayer_roundtrip");
+    let _ = std::fs::remove_dir_all(&tmp_dir);
+
+    let nats_server = NatsServerForTesting::new(&[]).await;
+    let nats_publisher = NatsPublisherForTesting::new(nats_server.port).await;
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+
+    let dir = tmp_dir.clone();
+    let archiver_handle = tokio::spawn(async move {
+        let args = make_test_args(nats_server.port, &dir);
+        archiver::run(args, shutdown_rx).await.unwrap();
+    });
+
+    sleep(Duration::from_secs(1)).await;
+
+    let all_events = make_all_event_types();
+    for (event, _) in &all_events {
+        nats_publisher
+            .publish(Subject::NetMsg.to_string(), event.encode_to_vec())
+            .await;
+    }
+
+    sleep(Duration::from_millis(500)).await;
+    shutdown_tx.send(true).unwrap();
+    archiver_handle.await.unwrap();
+
+    let archive = replayer::read_archive(&tmp_dir.join("test.0.bin.zst")).unwrap();
+
+    assert_eq!(archive.header.version, 1);
+    assert_eq!(archive.events.len(), all_events.len());
+
+    for ((sent, _label), decoded) in all_events.iter().zip(archive.events.iter()) {
+        assert_eq!(sent.peer_observer_event, decoded.peer_observer_event);
+    }
+
+    let _ = std::fs::remove_dir_all(&tmp_dir);
+}
+
 #[tokio::test]
 async fn test_compression_integrity() {
     setup();

--- a/tools/archiver/tests/integration.rs
+++ b/tools/archiver/tests/integration.rs
@@ -425,6 +425,55 @@ async fn test_replayer_roundtrip() {
 }
 
 #[tokio::test]
+async fn test_replayer_roundtrip_uncompressed() {
+    setup();
+
+    let tmp_dir = std::env::temp_dir().join(format!(
+        "archiver_test_replayer_roundtrip_uncompressed_{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&tmp_dir);
+
+    let nats_server = NatsServerForTesting::new(&[]).await;
+    let nats_publisher = NatsPublisherForTesting::new(nats_server.port).await;
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+
+    let dir = tmp_dir.clone();
+    let archiver_handle = tokio::spawn(async move {
+        let mut args = make_test_args(nats_server.port, &dir);
+        args.compression_level = 0;
+        archiver::run(args, shutdown_rx).await.unwrap();
+    });
+
+    sleep(Duration::from_secs(1)).await;
+
+    let all_events = make_all_event_types();
+    for (event, _) in &all_events {
+        nats_publisher
+            .publish(Subject::NetMsg.to_string(), event.encode_to_vec())
+            .await;
+    }
+
+    sleep(Duration::from_millis(500)).await;
+    shutdown_tx.send(true).unwrap();
+    archiver_handle.await.unwrap();
+
+    let archive_path = tmp_dir.join("test.0.bin");
+    assert!(archive_path.exists());
+
+    let archive = replayer::read_archive(&archive_path).unwrap();
+
+    assert_eq!(archive.header.version, 1);
+    assert_eq!(archive.events.len(), all_events.len());
+
+    for ((sent, _label), decoded) in all_events.iter().zip(archive.events.iter()) {
+        assert_eq!(sent.peer_observer_event, decoded.peer_observer_event);
+    }
+
+    let _ = std::fs::remove_dir_all(&tmp_dir);
+}
+
+#[tokio::test]
 async fn test_compression_integrity() {
     setup();
 

--- a/tools/archiver/tests/integration.rs
+++ b/tools/archiver/tests/integration.rs
@@ -10,7 +10,6 @@ use shared::{
     prost::Message,
     protobuf::{
         ebpf_extractor::{
-            addrman::{self, InsertNew},
             connection::{self, Connection, InboundConnection},
             ebpf,
             mempool::{self, Added},
@@ -63,7 +62,6 @@ fn make_test_args(nats_port: u16, output_dir: &std::path::Path) -> Args {
         log_level: log::Level::Info,
         messages: false,
         connections: false,
-        addrman: false,
         mempool: false,
         validation: false,
         rpc: false,
@@ -113,25 +111,7 @@ fn make_all_event_types() -> Vec<(Event, &'static str)> {
             .unwrap(),
             "connections",
         ),
-        // 3. ebpf addrman
-        (
-            Event::new(PeerObserverEvent::EbpfExtractor(Ebpf {
-                ebpf_event: Some(ebpf::EbpfEvent::Addrman(addrman::AddrmanEvent {
-                    event: Some(addrman::addrman_event::Event::New(InsertNew {
-                        addr: "127.0.0.1:8333".to_string(),
-                        addr_as: 1,
-                        bucket: 1,
-                        bucket_pos: 1,
-                        inserted: true,
-                        source: "127.0.0.1:8333".to_string(),
-                        source_as: 0,
-                    })),
-                })),
-            }))
-            .unwrap(),
-            "addrman",
-        ),
-        // 4. ebpf mempool
+        // 3. ebpf mempool
         (
             Event::new(PeerObserverEvent::EbpfExtractor(Ebpf {
                 ebpf_event: Some(ebpf::EbpfEvent::Mempool(mempool::MempoolEvent {
@@ -219,7 +199,6 @@ async fn run_filter_test(flag: &str, expected_count: usize) {
         match flag_owned.as_str() {
             "messages" => args.messages = true,
             "connections" => args.connections = true,
-            "addrman" => args.addrman = true,
             "mempool" => args.mempool = true,
             "validation" => args.validation = true,
             "rpc" => args.rpc = true,
@@ -274,7 +253,7 @@ async fn run_filter_test(flag: &str, expected_count: usize) {
 
 #[tokio::test]
 async fn test_filter_all() {
-    run_filter_test("all", 8).await;
+    run_filter_test("all", 7).await;
 }
 
 #[tokio::test]
@@ -285,11 +264,6 @@ async fn test_filter_messages() {
 #[tokio::test]
 async fn test_filter_connections() {
     run_filter_test("connections", 1).await;
-}
-
-#[tokio::test]
-async fn test_filter_addrman() {
-    run_filter_test("addrman", 1).await;
 }
 
 #[tokio::test]
@@ -390,7 +364,7 @@ async fn test_file_rotation_with_compression() {
     println!("total events:  {}", total_events);
     println!("===================================\n");
 
-    assert_eq!(total_events, 8);
+    assert_eq!(total_events, 7);
 
     let _ = std::fs::remove_dir_all(&tmp_dir);
 }

--- a/tools/archiver/tests/integration.rs
+++ b/tools/archiver/tests/integration.rs
@@ -67,12 +67,12 @@ fn make_test_args(nats_port: u16, output_dir: &std::path::Path) -> Args {
         rpc: false,
         p2p_extractor: false,
         log_extractor: false,
-        compression_level: 22,
+        compression_level: 3,
     }
 }
 
 fn make_all_event_types() -> Vec<(Event, &'static str)> {
-    vec![
+    let events = vec![
         // 1. ebpf message
         (
             Event::new(PeerObserverEvent::EbpfExtractor(Ebpf {
@@ -179,7 +179,23 @@ fn make_all_event_types() -> Vec<(Event, &'static str)> {
             .unwrap(),
             "log_extractor",
         ),
-    ]
+    ];
+
+    // Compile-time check: if a new PeerObserverEvent variant is added,
+    // this match becomes non-exhaustive and fails to compile.
+    match events[0].0.peer_observer_event.as_ref().unwrap() {
+        PeerObserverEvent::EbpfExtractor(e) => match e.ebpf_event.as_ref().unwrap() {
+            ebpf::EbpfEvent::Message(_) => (),
+            ebpf::EbpfEvent::Connection(_) => (),
+            ebpf::EbpfEvent::Mempool(_) => (),
+            ebpf::EbpfEvent::Validation(_) => (),
+        },
+        PeerObserverEvent::RpcExtractor(_) => (),
+        PeerObserverEvent::P2pExtractor(_) => (),
+        PeerObserverEvent::LogExtractor(_) => (),
+    }
+
+    events
 }
 
 async fn run_filter_test(flag: &str, expected_count: usize) {
@@ -204,7 +220,7 @@ async fn run_filter_test(flag: &str, expected_count: usize) {
             "rpc" => args.rpc = true,
             "p2p_extractor" => args.p2p_extractor = true,
             "log_extractor" => args.log_extractor = true,
-            _ => {} // compress_all
+            _ => {} // archive_all
         }
         archiver::run(args, shutdown_rx).await.unwrap();
     });

--- a/tools/archiver/tests/integration.rs
+++ b/tools/archiver/tests/integration.rs
@@ -304,10 +304,10 @@ async fn test_filter_log_extractor() {
 }
 
 #[tokio::test]
-async fn test_file_rotation() {
+async fn test_file_rotation_with_compression() {
     setup();
 
-    let tmp_dir = std::env::temp_dir().join("archiver_test_rotation");
+    let tmp_dir = std::env::temp_dir().join("archiver_test_rotation_with_compression");
     let _ = std::fs::remove_dir_all(&tmp_dir);
 
     let nats_server = NatsServerForTesting::new(&[]).await;
@@ -317,7 +317,8 @@ async fn test_file_rotation() {
     let dir = tmp_dir.clone();
     let archiver_handle = tokio::spawn(async move {
         let mut args = make_test_args(nats_server.port, &dir);
-        args.max_file_size = 100; // force rotation after ~1-2 events
+        args.max_file_size = 1; // force rotation on every event
+        args.compression_level = 1;
         archiver::run(args, shutdown_rx).await.unwrap();
     });
 
@@ -485,6 +486,22 @@ async fn test_compression_integrity() {
             "decompressed SHA-256 of {} must match manifest checksum",
             zst_name
         );
+
+        let compressed_checksum = entry["compressed_checksum"].as_str().unwrap();
+        let compressed_size = entry["compressed_size_bytes"].as_integer().unwrap() as u64;
+
+        let raw_zst = std::fs::read(&zst_path).unwrap();
+        let actual_compressed_checksum = format!("{:x}", sha2::Sha256::digest(&raw_zst));
+        assert_eq!(
+            actual_compressed_checksum, compressed_checksum,
+            "SHA-256 of raw .zst must match manifest compressed_checksum"
+        );
+
+        let file_size = std::fs::metadata(&zst_path).unwrap().len();
+        assert_eq!(
+            compressed_size, file_size,
+            "compressed_size_bytes must match file size on disk"
+        );
     }
 
     let _ = std::fs::remove_dir_all(&tmp_dir);
@@ -540,6 +557,15 @@ async fn test_no_compression() {
     assert_eq!(
         actual_checksum, expected_checksum,
         "SHA-256 of raw .bin must match manifest checksum"
+    );
+
+    assert!(
+        files[0].get("compressed_checksum").is_none(),
+        "compressed_checksum should not be present without compression"
+    );
+    assert!(
+        files[0].get("compressed_size_bytes").is_none(),
+        "compressed_size_bytes should not be present without compression"
     );
 
     let _ = std::fs::remove_dir_all(&tmp_dir);

--- a/tools/archiver/tests/integration.rs
+++ b/tools/archiver/tests/integration.rs
@@ -25,6 +25,7 @@ use shared::{
     simple_logger,
     testing::{nats_publisher::NatsPublisherForTesting, nats_server::NatsServerForTesting},
     tokio::{self, sync::watch, time::sleep},
+    zstd,
 };
 use std::{fs::File, io::Read, sync::Once, time::Duration};
 

--- a/tools/archiver/tests/integration.rs
+++ b/tools/archiver/tests/integration.rs
@@ -26,12 +26,7 @@ use shared::{
     testing::{nats_publisher::NatsPublisherForTesting, nats_server::NatsServerForTesting},
     tokio::{self, sync::watch, time::sleep},
 };
-use std::{
-    fs::File,
-    io::{BufReader, Read},
-    sync::Once,
-    time::Duration,
-};
+use std::{fs::File, io::Read, sync::Once, time::Duration};
 
 static INIT: Once = Once::new();
 
@@ -46,7 +41,6 @@ fn setup() {
 
 fn make_test_args(nats_port: u16, output_dir: &std::path::Path) -> Args {
     Args {
-        // aqui nao deveria ser Args::new?
         nats: nats_util::NatsArgs {
             address: format!("127.0.0.1:{}", nats_port),
             username: None,
@@ -55,7 +49,7 @@ fn make_test_args(nats_port: u16, output_dir: &std::path::Path) -> Args {
         },
         output_dir: output_dir.to_path_buf(),
         base_name: "test".to_string(),
-        max_file_size: 1_073_741_824, // nao seria melhor pegar o valor direto de um arquivo configuravel?
+        max_file_size: 104_857_600,
         log_level: log::Level::Info,
         messages: false,
         connections: false,
@@ -65,6 +59,7 @@ fn make_test_args(nats_port: u16, output_dir: &std::path::Path) -> Args {
         rpc: false,
         p2p_extractor: false,
         log_extractor: false,
+        compression_level: 22,
     }
 }
 
@@ -238,13 +233,12 @@ async fn run_filter_test(flag: &str, expected_count: usize) {
     shutdown_tx.send(true).unwrap();
     archiver_handle.await.unwrap();
 
-    // ler e verificar
-    let file = File::open(tmp_dir.join("test.0.bin")).unwrap();
-    let mut reader = BufReader::new(file);
+    let file = File::open(tmp_dir.join("test.0.bin.zst")).unwrap();
+    let mut reader = zstd::Decoder::new(file).unwrap();
 
     let mut header = [0u8; 16];
     reader.read_exact(&mut header).unwrap();
-    assert_eq!(&header[0..8], b"POBS_ARC");
+    assert_eq!(&header[0..2], b"PA");
 
     let mut buf = Vec::new();
     reader.read_to_end(&mut buf).unwrap();
@@ -340,33 +334,28 @@ async fn test_file_rotation() {
     shutdown_tx.send(true).unwrap();
     archiver_handle.await.unwrap();
 
-    // count how many .bin files were created
-    let bin_files: Vec<_> = std::fs::read_dir(&tmp_dir)
+    // count how many .bin.zst files were created
+    let zst_files: Vec<_> = std::fs::read_dir(&tmp_dir)
         .unwrap()
         .filter_map(|e| e.ok())
-        .filter(|e| {
-            e.path()
-                .extension()
-                .map(|ext| ext == "bin")
-                .unwrap_or(false)
-        })
+        .filter(|e| e.path().to_string_lossy().ends_with(".bin.zst"))
         .collect();
 
     assert!(
-        bin_files.len() > 1,
+        zst_files.len() > 1,
         "expected multiple files from rotation, got {}",
-        bin_files.len()
+        zst_files.len()
     );
 
-    // read all files and count total events
+    // decompress and count total events
     let mut total_events = 0;
-    for entry in &bin_files {
+    for entry in &zst_files {
         let file = File::open(entry.path()).unwrap();
-        let mut reader = BufReader::new(file);
+        let mut reader = zstd::Decoder::new(file).unwrap();
 
         let mut header = [0u8; 16];
         reader.read_exact(&mut header).unwrap();
-        assert_eq!(&header[0..8], b"POBS_ARC");
+        assert_eq!(&header[0..2], b"PA");
 
         let mut buf = Vec::new();
         reader.read_to_end(&mut buf).unwrap();
@@ -382,7 +371,7 @@ async fn test_file_rotation() {
     }
 
     println!("\n========== ROTATION TEST ==========");
-    println!("files created: {}", bin_files.len());
+    println!("files created: {}", zst_files.len());
     println!("total events:  {}", total_events);
     println!("===================================\n");
 
@@ -454,6 +443,61 @@ async fn test_compression_integrity() {
             zst_name
         );
     }
+
+    let _ = std::fs::remove_dir_all(&tmp_dir);
+}
+
+#[tokio::test]
+async fn test_no_compression() {
+    setup();
+
+    let tmp_dir = std::env::temp_dir().join("archiver_test_no_compression");
+    let _ = std::fs::remove_dir_all(&tmp_dir);
+
+    let nats_server = NatsServerForTesting::new(&[]).await;
+    let nats_publisher = NatsPublisherForTesting::new(nats_server.port).await;
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+
+    let dir = tmp_dir.clone();
+    let archiver_handle = tokio::spawn(async move {
+        let mut args = make_test_args(nats_server.port, &dir);
+        args.compression_level = 0;
+        archiver::run(args, shutdown_rx).await.unwrap();
+    });
+
+    sleep(Duration::from_secs(1)).await;
+
+    let all_events = make_all_event_types();
+    for (event, _) in &all_events {
+        nats_publisher
+            .publish(Subject::NetMsg.to_string(), event.encode_to_vec())
+            .await;
+    }
+
+    sleep(Duration::from_millis(500)).await;
+    shutdown_tx.send(true).unwrap();
+    archiver_handle.await.unwrap();
+
+    // should be .bin, not .bin.zst
+    let bin_path = tmp_dir.join("test.0.bin");
+    let zst_path = tmp_dir.join("test.0.bin.zst");
+    assert!(bin_path.exists(), "test.0.bin should exist");
+    assert!(!zst_path.exists(), "test.0.bin.zst should not exist");
+
+    // manifest should reference .bin
+    let manifest_str = std::fs::read_to_string(tmp_dir.join("test.manifest.toml")).unwrap();
+    let manifest: toml::Value = manifest_str.parse().unwrap();
+    let files = manifest["files"].as_array().unwrap();
+    assert_eq!(files[0]["name"].as_str().unwrap(), "test.0.bin");
+
+    // checksum should match raw file content
+    let raw = std::fs::read(&bin_path).unwrap();
+    let actual_checksum = format!("{:x}", sha2::Sha256::digest(&raw));
+    let expected_checksum = files[0]["checksum"].as_str().unwrap();
+    assert_eq!(
+        actual_checksum, expected_checksum,
+        "SHA-256 of raw .bin must match manifest checksum"
+    );
 
     let _ = std::fs::remove_dir_all(&tmp_dir);
 }

--- a/tools/archiver/tests/integration.rs
+++ b/tools/archiver/tests/integration.rs
@@ -224,7 +224,7 @@ async fn run_filter_test(flag: &str, expected_count: usize) {
             "rpc" => args.rpc = true,
             "p2p_extractor" => args.p2p_extractor = true,
             "log_extractor" => args.log_extractor = true,
-            _ => {} // show_all
+            _ => {} // compress_all
         }
         archiver::run(args, shutdown_rx).await.unwrap();
     });

--- a/tools/replayer/Cargo.toml
+++ b/tools/replayer/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "replayer"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+shared = { path = "../../shared" }
+zstd = "0.13"

--- a/tools/replayer/Cargo.toml
+++ b/tools/replayer/Cargo.toml
@@ -5,4 +5,3 @@ edition = "2021"
 
 [dependencies]
 shared = { path = "../../shared" }
-zstd = "0.13"

--- a/tools/replayer/README.md
+++ b/tools/replayer/README.md
@@ -1,0 +1,32 @@
+# `replayer`
+
+Reads peer-observer archive files and prints decoded events to stdout.
+
+Supports:
+- `.bin`
+- `.bin.zst`
+
+## Usage
+
+```bash
+cargo run -p replayer -- archive/test.0.bin
+cargo run -p replayer -- archive/test.0.bin.zst
+cargo run -p replayer -- archive/test.0.bin archive/test.1.bin.zst
+```
+
+## Example output
+
+```text
+header: version=1 git=abcd1234
+[1] ts=1234567890 ebpf: ...
+[2] ts=1234567891 ebpf: ...
+total: 2 events
+```
+
+## Help
+
+```
+Read and display peer-observer archive files
+
+Usage: replayer <file.bin[.zst]> [file2.bin[.zst] ...]
+```

--- a/tools/replayer/src/lib.rs
+++ b/tools/replayer/src/lib.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsStr;
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
@@ -18,9 +19,13 @@ pub struct Archive {
 }
 
 pub fn read_archive(path: &Path) -> std::io::Result<Archive> {
-    let file = File::open(path)?;
+    let mut file = File::open(path)?;
     let mut buf = Vec::new();
-    zstd::Decoder::new(file)?.read_to_end(&mut buf)?;
+    if path.extension() == Some(OsStr::new("zst")) {
+        zstd::Decoder::new(file)?.read_to_end(&mut buf)?;
+    } else {
+        file.read_to_end(&mut buf)?;
+    }
 
     if buf.len() < HEADER_SIZE {
         return Err(std::io::Error::other(format!(

--- a/tools/replayer/src/lib.rs
+++ b/tools/replayer/src/lib.rs
@@ -52,12 +52,13 @@ pub fn read_archive(path: &Path) -> std::io::Result<Archive> {
     let mut events = Vec::new();
 
     while cursor < data.len() {
-        let event = Event::decode_length_delimited(&data[cursor..]).map_err(|e| {
-            std::io::Error::other(format!("decode error at byte {}: {}", cursor, e))
-        })?;
-        let size = event.encoded_len();
-        let varint_len = shared::prost::length_delimiter_len(size);
-        cursor += varint_len + size;
+        let mut wire = &data[cursor..];
+        let payload_len = shared::prost::decode_length_delimiter(&mut wire)
+            .map_err(|e| std::io::Error::other(format!("bad length at byte {cursor}: {e}")))?;
+        let varint_len = (data.len() - cursor) - wire.len();
+        let event = Event::decode(&data[cursor + varint_len..cursor + varint_len + payload_len])
+            .map_err(|e| std::io::Error::other(format!("decode error at byte {cursor}: {e}")))?;
+        cursor += varint_len + payload_len;
         events.push(event);
     }
 

--- a/tools/replayer/src/lib.rs
+++ b/tools/replayer/src/lib.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 
 use shared::prost::Message;
 use shared::protobuf::event::Event;
+use shared::zstd;
 
 const HEADER_SIZE: usize = 16;
 

--- a/tools/replayer/src/lib.rs
+++ b/tools/replayer/src/lib.rs
@@ -1,0 +1,59 @@
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
+
+use shared::prost::Message;
+use shared::protobuf::event::Event;
+
+const HEADER_SIZE: usize = 16;
+
+pub struct ArchiveHeader {
+    pub version: u8,
+    pub git_hash: [u8; 4],
+}
+
+pub struct Archive {
+    pub header: ArchiveHeader,
+    pub events: Vec<Event>,
+}
+
+pub fn read_archive(path: &Path) -> std::io::Result<Archive> {
+    let file = File::open(path)?;
+    let mut buf = Vec::new();
+    zstd::Decoder::new(file)?.read_to_end(&mut buf)?;
+
+    if buf.len() < HEADER_SIZE {
+        return Err(std::io::Error::other(format!(
+            "file too small: {} bytes",
+            buf.len()
+        )));
+    }
+
+    if &buf[0..2] != b"PA" {
+        return Err(std::io::Error::other(format!(
+            "invalid magic: {:02x}{:02x} (expected \"PA\")",
+            buf[0], buf[1]
+        )));
+    }
+
+    let header = ArchiveHeader {
+        version: buf[2],
+        git_hash: [buf[3], buf[4], buf[5], buf[6]],
+    };
+
+    let data = &buf[HEADER_SIZE..];
+    let mut cursor = 0;
+    let mut events = Vec::new();
+
+    while cursor < data.len() {
+        let event = Event::decode_length_delimited(&data[cursor..]).map_err(|e| {
+            std::io::Error::other(format!("decode error at byte {}: {}", cursor, e))
+        })?;
+        let size = event.encoded_len();
+        let varint_len = shared::prost::length_delimiter_len(size);
+        cursor += varint_len + size;
+        events.push(event);
+    }
+
+    Ok(Archive { header, events })
+}

--- a/tools/replayer/src/main.rs
+++ b/tools/replayer/src/main.rs
@@ -1,0 +1,53 @@
+use std::env;
+use std::path::Path;
+
+use shared::protobuf::event::event::PeerObserverEvent;
+
+fn main() {
+    let files: Vec<String> = env::args().skip(1).collect();
+    if files.is_empty() {
+        eprintln!("usage: replayer <file.bin.zst> [file2.bin.zst ...]");
+        std::process::exit(1);
+    }
+
+    for path in &files {
+        if files.len() > 1 {
+            println!("=== {} ===", path);
+        }
+        match replayer::read_archive(Path::new(path)) {
+            Ok(archive) => {
+                println!(
+                    "header: version={} git={}",
+                    archive.header.version,
+                    archive
+                        .header
+                        .git_hash
+                        .iter()
+                        .map(|b| format!("{:02x}", b))
+                        .collect::<String>()
+                );
+                for (i, event) in archive.events.iter().enumerate() {
+                    let n = i + 1;
+                    let ts = event.timestamp;
+                    match &event.peer_observer_event {
+                        Some(PeerObserverEvent::EbpfExtractor(e)) => {
+                            println!("[{n}] ts={ts} ebpf: {}", e.ebpf_event.as_ref().unwrap())
+                        }
+                        Some(PeerObserverEvent::RpcExtractor(r)) => {
+                            println!("[{n}] ts={ts} rpc: {}", r.rpc_event.as_ref().unwrap())
+                        }
+                        Some(PeerObserverEvent::P2pExtractor(p)) => {
+                            println!("[{n}] ts={ts} p2p: {}", p.p2p_event.as_ref().unwrap())
+                        }
+                        Some(PeerObserverEvent::LogExtractor(l)) => {
+                            println!("[{n}] ts={ts} log: {}", l.log_event.as_ref().unwrap())
+                        }
+                        None => println!("[{n}] ts={ts} <unknown>"),
+                    }
+                }
+                println!("total: {} events", archive.events.len());
+            }
+            Err(e) => eprintln!("error reading {}: {}", path, e),
+        }
+    }
+}

--- a/tools/replayer/src/main.rs
+++ b/tools/replayer/src/main.rs
@@ -5,9 +5,11 @@ use shared::protobuf::event::event::PeerObserverEvent;
 
 fn main() {
     let files: Vec<String> = env::args().skip(1).collect();
-    if files.is_empty() {
-        eprintln!("usage: replayer <file.bin.zst> [file2.bin.zst ...]");
-        std::process::exit(1);
+    if files.is_empty() || files.iter().any(|f| f == "--help" || f == "-h") {
+        println!("Read and display peer-observer archive files");
+        println!();
+        println!("Usage: replayer <file.bin[.zst]> [file2.bin[.zst] ...]");
+        return;
     }
 
     for path in &files {


### PR DESCRIPTION
## Summary

Apply the OS-assigned-port + readiness-oneshot pattern from #358 (p2p) and #365 (websocket) to the rpc-extractor integration tests, closing the rpc-extractor portion of #382.

Two non-trivial bits worth calling out:

`shared::metricserver::start` now returns `Result<SocketAddr, io::Error>` so callers can discover the bound port, and `rpc_extractor::run` accepts an optional `oneshot::Sender<SocketAddr>`. The body of `run()` is reordered so RPC client construction and NATS connect happen *before* `metricserver::start`, matching the p2p shape. The readiness barrier now catches RPC and NATS startup failures, not just the metricserver bind. (This is the deliberate ordering choice, different from #417.)

The `check()` harness also picks up the p2p-style `tokio::select!` race against the extractor task handle (so startup failures surface as real errors, not `channel closed` panics) and a poll-until-predicate consume loop (so three state-dependent tests (`getchaintxstats`, `getorphantxs`, `getrawaddrman`) wait for a readiness marker instead of asserting on whatever lands first). `TEST_TIMEOUT_SECONDS` bumped 5 → 10 to cover bitcoind variance under load.

Companion work in flight on separate stacked branches: the `tools/metrics` half of #382 (same pattern, plus a marker-based pipeline-readiness barrier for the cross-connection NATS subscribe race) and the relational `tx_rate ≈ window_tx_count / window_interval` assertion change in `test_integration_rpc_getchaintxstats` (kept out of this PR for scope).

Fixes #382 (rpc-extractor). Alternative to #417.

## Testing

50/50 metrics + 20/20 rpc-extractor green on a `--test-threads=2` Linux stress run (NixOS x86_64, 4-core) against an earlier tip; fresh 10/10 rpc-extractor green on the post-rebase tip. Zero `AddrInUse`, zero readiness-barrier panics across either run.

Occasional `generatetoaddress` timeout at `--test-threads=4` when `getchaintxstats` and `estimatesmartfee` race for bitcoind CPU. Separate concern from the port race, never manifests as `AddrInUse`.
